### PR TITLE
feat: add breadcrumb navigation to agent pages

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -226,6 +226,14 @@ export default function AgentRunner({ agent }) {
 
   return (
     <div className="max-w-3xl mx-auto animate-fade-in">
+      {/* Breadcrumb */}
+      <a
+        href="/"
+        className="inline-block mb-4 text-xs dark:text-text-muted text-gray-400 hover:underline"
+      >
+        ← All agents
+      </a>
+      
       {/* Agent Header */}
       <div className="flex items-start gap-4 mb-5">
         <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
Closes #10

## Changes Made
- Added "← All agents" breadcrumb at the top of every agent page
- Clicking navigates back to home page (/)
- Modified AgentRunner.jsx only — no new files

## Testing
- Breadcrumb visible at top of every agent page ✅
- Navigates to home page on click ✅
- Muted color, small text, not distracting ✅
- Underline on hover only ✅
- Works on mobile ✅
- Dark mode works ✅
- Light mode works ✅