### PR TITLE
feat: add 'New' badge for recently added agents

### DIFF
--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -19,6 +19,7 @@ const agents = [
     icon: 'FileText',
     provider: 'anthropic',
     model: 'claude-opus-4-20250514',
+    createdAt: '2025-05-06',
     exampleInputs: {
       pdf_text: "ABSTRACT\n\nRecent advancements in Large Language Models (LLMs) have revolutionized the field of Natural Language Processing. This paper explores the performance of transformer-based architectures in zero-shot learning scenarios across diverse linguistic tasks. Our findings indicate that model scale significantly correlates with emergent capabilities, particularly in reasoning and symbolic manipulation. However, the presence of hallucinatory outputs remains a critical challenge for production-ready deployments.\n\nMETHODOLOGY\n\nWe evaluated three variants of the 'GigaChat' model on the benchmarks GLUE, SuperGLUE, and MMLU. Data was collected over a six-month period...",
       focus: "methodology and main findings",

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -23,6 +23,14 @@ export default function AgentCard({ agent }) {
   const provLabel = providerLabels[agent.provider] || agent.provider
   const { isFavorite, toggleFavorite } = useFavorites()
   const favorited = isFavorite(agent.id)
+  
+  // Check if agent was added in the last 7 days
+  const isNew = agent.createdAt && (() => {
+    const created = new Date(agent.createdAt)
+    const now = new Date()
+    const diffDays = (now - created) / (1000 * 60 * 60 * 24)
+    return diffDays <= 7
+  })()
 
   const handleFavorite = (e) => {
     e.preventDefault()  // prevent Link navigation
@@ -48,6 +56,11 @@ export default function AgentCard({ agent }) {
             bg-gray-100 text-gray-500 border dark:border-border border-gray-200">
             {agent.category}
           </span>
+          {isNew && (
+            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">
+              New
+            </span>
+          )}
           <button
             onClick={handleFavorite}
             className={`p-1 rounded-md transition-all duration-200


### PR DESCRIPTION
## Description\nThis PR adds a 'New' badge to agent cards for agents added within the last 7 days, giving visibility to new contributions.\n\n## Changes\n- Added createdAt field to agent entries in registry.js\n- Added logic to check if agent is within 7 days\n- Render green 'New' pill on qualifying agent cards\n- Pure date-based check, no backend required\n\n## Related Issue\nCloses #24\n\n## Testing\n- Tested with sample createdAt dates\n- Badge appears only for agents < 7 days old\n- No visual change for older agents