### PR TITLE
feat: add voice input to all text fields via native Web Speech API

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -1,172 +1,190 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import * as Icons from 'lucide-react'
-import { Loader2, RotateCcw, Clock, Zap, StopCircle, ChevronDown, ChevronRight, Sparkles, RotateCw } from 'lucide-react'
-import ApiKeyBar from './ApiKeyBar'
-import OutputRenderer from './OutputRenderer'
-import ErrorCard from './ErrorCard'
-import { useApiKey } from '../lib/useApiKey'
-import { streamAgent } from '../lib/llmAdapter'
+import { useState, useEffect, useRef, useCallback } from "react";
+import * as Icons from "lucide-react";
+import {
+  Loader2,
+  RotateCcw,
+  Clock,
+  Zap,
+  StopCircle,
+  ChevronDown,
+  ChevronRight,
+  Sparkles,
+  RotateCw,
+} from "lucide-react";
+import ApiKeyBar from "./ApiKeyBar";
+import OutputRenderer from "./OutputRenderer";
+import ErrorCard from "./ErrorCard";
+import VoiceInput from "./VoiceInput";
+import { useApiKey } from "../lib/useApiKey";
+import { streamAgent } from "../lib/llmAdapter";
 
-const providerLabels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', any: 'Any' }
+const providerLabels = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  gemini: "Gemini",
+  any: "Any",
+};
 
 const MODEL_MAP = {
-  openai: 'gpt-4o',
-  anthropic: 'claude-opus-4-20250514',
-  gemini: 'gemini-2.5-flash',
-}
+  openai: "gpt-4o",
+  anthropic: "claude-opus-4-20250514",
+  gemini: "gemini-2.5-flash",
+};
 
 const LOADING_MESSAGES = [
-  '⚙️ Agent is grinding for you...',
-  '🧠 Big brain moment loading...',
-  '✨ Cooking something fire...',
-  '🤖 Agent is in its era...',
-  '💀 This might actually go crazy...',
-  '🔥 Almost done, hold tight...',
-  '🚀 Sending it...',
-  '👀 Your agent is locked in...',
-]
+  "⚙️ Agent is grinding for you...",
+  "🧠 Big brain moment loading...",
+  "✨ Cooking something fire...",
+  "🤖 Agent is in its era...",
+  "💀 This might actually go crazy...",
+  "🔥 Almost done, hold tight...",
+  "🚀 Sending it...",
+  "👀 Your agent is locked in...",
+];
 
 export default function AgentRunner({ agent }) {
-  const { provider, setProvider, apiKey, setApiKey, saveForSession, setSaveForSession } = useApiKey()
+  const {
+    provider,
+    setProvider,
+    apiKey,
+    setApiKey,
+    saveForSession,
+    setSaveForSession,
+  } = useApiKey();
 
-  const [inputs, setInputs] = useState({})
-  const [output, setOutput] = useState(null)
-  const [streamingOutput, setStreamingOutput] = useState('')
-  const [isStreaming, setIsStreaming] = useState(false)
-  const [error, setError] = useState(null)
-  const [loading, setLoading] = useState(false)
-  const [duration, setDuration] = useState(null)
-  const [selectedModel, setSelectedModel] = useState(MODEL_MAP[provider] || MODEL_MAP.openai)
-  const [playgroundOpen, setPlaygroundOpen] = useState(false)
-  const [customPrompt, setCustomPrompt] = useState(agent.systemPrompt)
-  const [msgIndex, setMsgIndex] = useState(0)
+  const [inputs, setInputs] = useState({});
+  const [output, setOutput] = useState(null);
+  const [streamingOutput, setStreamingOutput] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [duration, setDuration] = useState(null);
+  const [selectedModel, setSelectedModel] = useState(
+    MODEL_MAP[provider] || MODEL_MAP.openai,
+  );
+  const [playgroundOpen, setPlaygroundOpen] = useState(false);
+  const [customPrompt, setCustomPrompt] = useState(agent.systemPrompt);
+  const [msgIndex, setMsgIndex] = useState(0);
 
-  const isPromptModified = customPrompt !== agent.systemPrompt
-  const abortControllerRef = useRef(null)
-  const runButtonRef = useRef(null)
+  const isPromptModified = customPrompt !== agent.systemPrompt;
+  const abortControllerRef = useRef(null);
 
   useEffect(() => {
-    setSelectedModel(MODEL_MAP[provider] || MODEL_MAP.openai)
-  }, [provider])
+    setSelectedModel(MODEL_MAP[provider] || MODEL_MAP.openai);
+  }, [provider]);
 
   useEffect(() => {
     if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
-      abortControllerRef.current = null
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
     }
-    setOutput(null)
-    setStreamingOutput('')
-    setIsStreaming(false)
-    setError(null)
-    setDuration(null)
-    setCustomPrompt(agent.systemPrompt)
-    setPlaygroundOpen(false)
+    setOutput(null);
+    setStreamingOutput("");
+    setIsStreaming(false);
+    setError(null);
+    setDuration(null);
+    setCustomPrompt(agent.systemPrompt);
+    setPlaygroundOpen(false);
 
-    const defaults = {}
+    const defaults = {};
     agent.inputs.forEach((input) => {
       if (input.defaultValue !== undefined) {
-        defaults[input.id] = input.defaultValue
-      } else if (input.type === 'multiselect') {
-        defaults[input.id] = []
+        defaults[input.id] = input.defaultValue;
+      } else if (input.type === "multiselect") {
+        defaults[input.id] = [];
       } else {
-        defaults[input.id] = ''
+        defaults[input.id] = "";
       }
-    })
-    setInputs(defaults)
+    });
+    setInputs(defaults);
 
-    if (agent.provider !== 'any') {
-      setProvider(agent.provider)
+    if (agent.provider !== "any") {
+      setProvider(agent.provider);
     } else if (agent.defaultProvider) {
-      setProvider(agent.defaultProvider)
+      setProvider(agent.defaultProvider);
     }
-  }, [agent.id])
+  }, [agent.id]);
 
   useEffect(() => {
-    if (!loading || isStreaming) return
+    if (!loading || isStreaming) return;
     const interval = setInterval(() => {
-      setMsgIndex((prev) => (prev + 1) % LOADING_MESSAGES.length)
-    }, 2500)
-    return () => clearInterval(interval)
-  }, [loading, isStreaming])
+      setMsgIndex((prev) => (prev + 1) % LOADING_MESSAGES.length);
+    }, 2500);
+    return () => clearInterval(interval);
+  }, [loading, isStreaming]);
 
   const updateInput = (id, value) => {
-    setInputs((prev) => ({ ...prev, [id]: value }))
-  }
-
-  // Helper to calculate counts
-  const getTextStats = (text) => {
-    const content = text || '';
-    const charCount = content.length;
-    const wordCount = content.trim() === '' ? 0 : content.trim().split(/\s+/).length;
-    return `${charCount} characters · ${wordCount} words`;
-  }
+    setInputs((prev) => ({ ...prev, [id]: value }));
+  };
 
   const toggleMultiselect = (id, option) => {
     setInputs((prev) => {
-      const current = prev[id] || []
+      const current = prev[id] || [];
       return {
         ...prev,
         [id]: current.includes(option)
           ? current.filter((o) => o !== option)
           : [...current, option],
-      }
-    })
-  }
+      };
+    });
+  };
 
   const buildUserMessage = () => {
-    const parts = []
+    const parts = [];
     agent.inputs.forEach((input) => {
-      const val = inputs[input.id]
-      if (!val || (Array.isArray(val) && val.length === 0)) return
-      parts.push(Array.isArray(val)
-        ? `${input.label}: ${val.join(', ')}`
-        : `${input.label}: ${val}`
-      )
-    })
-    return parts.join('\n\n')
-  }
+      const val = inputs[input.id];
+      if (!val || (Array.isArray(val) && val.length === 0)) return;
+      parts.push(
+        Array.isArray(val)
+          ? `${input.label}: ${val.join(", ")}`
+          : `${input.label}: ${val}`,
+      );
+    });
+    return parts.join("\n\n");
+  };
 
   const canRun = () => {
-    if (!apiKey) return false
+    if (!apiKey) return false;
     return agent.inputs
       .filter((i) => i.required)
       .every((i) => {
-        const v = inputs[i.id]
-        if (Array.isArray(v)) return v.length > 0
-        return v && v.trim() !== ''
-      })
-  }
+        const v = inputs[i.id];
+        if (Array.isArray(v)) return v.length > 0;
+        return v && v.trim() !== "";
+      });
+  };
 
   const hasInputContent = () => {
-    if (output || streamingOutput || error) return true
+    if (output || streamingOutput || error) return true;
     return agent.inputs.some((input) => {
-      const v = inputs[input.id]
-      if (Array.isArray(v)) return v.length > 0
-      return v && v !== (input.defaultValue ?? '')
-    })
-  }
+      const v = inputs[input.id];
+      if (Array.isArray(v)) return v.length > 0;
+      return v && v !== (input.defaultValue ?? "");
+    });
+  };
 
   const handleChunk = useCallback((chunk) => {
-    setStreamingOutput((prev) => prev + chunk)
-    setIsStreaming(true)
-  }, [])
-
+    setStreamingOutput((prev) => prev + chunk);
+    setIsStreaming(true);
+  }, []);
 
   const handleRun = async () => {
-    setLoading(true)
-    setError(null)
-    setOutput(null)
-    setStreamingOutput('')
-    setIsStreaming(false)
-    setDuration(null)
-    setMsgIndex(0)
+    setLoading(true);
+    setError(null);
+    setOutput(null);
+    setStreamingOutput("");
+    setIsStreaming(false);
+    setDuration(null);
+    setMsgIndex(0);
 
-    const controller = new AbortController()
-    abortControllerRef.current = controller
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
     try {
-      const actualProvider = agent.provider === 'any' ? provider : agent.provider
-      const model = selectedModel || MODEL_MAP[actualProvider] || MODEL_MAP.openai
+      const actualProvider =
+        agent.provider === "any" ? provider : agent.provider;
+      const model =
+        selectedModel || MODEL_MAP[actualProvider] || MODEL_MAP.openai;
 
       const result = await streamAgent({
         provider: actualProvider,
@@ -176,73 +194,63 @@ export default function AgentRunner({ agent }) {
         userMessage: buildUserMessage(),
         onChunk: handleChunk,
         signal: controller.signal,
-      })
+      });
 
-      setOutput(result.content)
-      setStreamingOutput('')
-      setIsStreaming(false)
-      setDuration(result.duration)
+      setOutput(result.content);
+      setStreamingOutput("");
+      setIsStreaming(false);
+      setDuration(result.duration);
     } catch (err) {
-      if (err.name !== 'AbortError') {
-        setError(err.message)
+      if (err.name !== "AbortError") {
+        setError(err.message);
       }
     } finally {
-      setLoading(false)
-      abortControllerRef.current = null
+      setLoading(false);
+      abortControllerRef.current = null;
     }
-  }
-
-  const handleKeyDown = (e) => {
-  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-    e.preventDefault()
-
-    if (loading || !canRun()) return
-
-    runButtonRef.current?.click()
-  }
-}
+  };
 
   const handleStop = () => {
     if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
-      abortControllerRef.current = null
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
     }
-    setOutput(streamingOutput)
-    setStreamingOutput('')
-    setIsStreaming(false)
-    setLoading(false)
-  }
+    setOutput(streamingOutput);
+    setStreamingOutput("");
+    setIsStreaming(false);
+    setLoading(false);
+  };
 
   const handleClear = () => {
     if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
-      abortControllerRef.current = null
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
     }
-    setOutput(null)
-    setStreamingOutput('')
-    setIsStreaming(false)
-    setError(null)
-    setDuration(null)
+    setOutput(null);
+    setStreamingOutput("");
+    setIsStreaming(false);
+    setError(null);
+    setDuration(null);
 
-    const defaults = {}
+    const defaults = {};
     agent.inputs.forEach((input) => {
       if (input.defaultValue !== undefined) {
-        defaults[input.id] = input.defaultValue
-      } else if (input.type === 'multiselect') {
-        defaults[input.id] = []
+        defaults[input.id] = input.defaultValue;
+      } else if (input.type === "multiselect") {
+        defaults[input.id] = [];
       } else {
-        defaults[input.id] = ''
+        defaults[input.id] = "";
       }
-    })
-    setInputs(defaults)
-  }
+    });
+    setInputs(defaults);
+  };
 
   const handleFillExample = () => {
-    if (!agent.exampleInputs) return
-    setInputs((prev) => ({ ...prev, ...agent.exampleInputs }))
-  }
+    if (!agent.exampleInputs) return;
+    setInputs((prev) => ({ ...prev, ...agent.exampleInputs }));
+  };
 
-  const IconComponent = Icons[agent.icon] || Icons.Bot
+  const IconComponent = Icons[agent.icon] || Icons.Bot;
 
   return (
     <div className="max-w-3xl mx-auto animate-fade-in">
@@ -253,7 +261,7 @@ export default function AgentRunner({ agent }) {
       >
         ← All agents
       </a>
-      
+
       {/* Agent Header */}
       <div className="flex items-start gap-4 mb-5">
         <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center flex-shrink-0">
@@ -264,9 +272,11 @@ export default function AgentRunner({ agent }) {
             <h1 className="text-lg font-bold dark:text-text-primary text-gray-900">
               {agent.name}
             </h1>
-            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full
+            <span
+              className="text-[10px] font-medium px-2 py-0.5 rounded-full
               dark:bg-surface-input dark:text-text-muted dark:border-border
-              bg-gray-100 text-gray-500 border border-gray-200">
+              bg-gray-100 text-gray-500 border border-gray-200"
+            >
               {agent.category}
             </span>
             <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-accent/10 text-accent border border-accent/20">
@@ -301,60 +311,70 @@ export default function AgentRunner({ agent }) {
               {input.required && <span className="text-error ml-0.5">*</span>}
             </label>
 
-            {input.type === 'text' && (
-              <input
-                type="text"
-                value={inputs[input.id] || ''}
-                onChange={(e) => updateInput(input.id, e.target.value)}
-                placeholder={input.placeholder}
-                className="w-full h-9 px-3 rounded-md text-sm transition-colors
-                  dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
-                  bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
-                  focus:ring-1 focus:ring-accent focus:border-accent outline-none"
-              />
+            {input.type === "text" && (
+              <div className="relative">
+                <input
+                  type="text"
+                  value={inputs[input.id] || ""}
+                  onChange={(e) => updateInput(input.id, e.target.value)}
+                  placeholder={input.placeholder}
+                  className="w-full h-9 pl-3 pr-10 rounded-md text-sm transition-colors
+                    dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
+                    bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                />
+                <VoiceInput
+                  value={inputs[input.id] || ""}
+                  onChange={(v) => updateInput(input.id, v)}
+                  className="top-1/2 -translate-y-1/2 right-1.5"
+                />
+              </div>
             )}
 
-            {input.type === 'textarea' && (
-  <>
-    <textarea
-      value={inputs[input.id] || ''}
-      onChange={(e) => updateInput(input.id, e.target.value)}
-      onKeyDown={handleKeyDown}
-      placeholder={input.placeholder}
-      rows={4}
-      className="w-full px-3 py-2 rounded-md text-sm transition-colors resize-y
-        dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
-        bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
-        focus:ring-1 focus:ring-accent focus:border-accent outline-none"
-    />
-    <div className="text-[12px] text-right mt-1 dark:text-text-muted text-gray-400">
-      {getTextStats(inputs[input.id])}
-    </div>
-  </>
-)}
-{input.type === 'code' && (
-  <>
-    <textarea
-      value={inputs[input.id] || ''}
-      onChange={(e) => updateInput(input.id, e.target.value)}
-      onKeyDown={handleKeyDown}
-      placeholder={input.placeholder}
-      rows={8}
-      className="w-full px-3 py-2 rounded-md text-xs font-mono transition-colors resize-y leading-relaxed
-        dark:bg-[#0d1117] dark:border-border dark:text-green-300 dark:placeholder:text-text-muted
-        bg-gray-900 border border-gray-700 text-green-400 placeholder:text-gray-500
-        focus:ring-1 focus:ring-accent focus:border-accent outline-none"
-      spellCheck={false}
-    />
-    <div className="text-[12px] text-right mt-1 dark:text-text-muted text-gray-400">
-      {getTextStats(inputs[input.id])}
-    </div>
-  </>
-)}
+            {input.type === "textarea" && (
+              <div className="relative">
+                <textarea
+                  value={inputs[input.id] || ""}
+                  onChange={(e) => updateInput(input.id, e.target.value)}
+                  placeholder={input.placeholder}
+                  rows={4}
+                  className="w-full pl-3 pr-10 py-2 rounded-md text-sm transition-colors resize-y
+                    dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
+                    bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                />
+                <VoiceInput
+                  value={inputs[input.id] || ""}
+                  onChange={(v) => updateInput(input.id, v)}
+                  className="top-2 right-2"
+                />
+              </div>
+            )}
 
-            {input.type === 'select' && (
+            {input.type === "code" && (
+              <div className="relative">
+                <textarea
+                  value={inputs[input.id] || ""}
+                  onChange={(e) => updateInput(input.id, e.target.value)}
+                  placeholder={input.placeholder}
+                  rows={8}
+                  className="w-full pl-3 pr-10 py-2 rounded-md text-xs font-mono transition-colors resize-y leading-relaxed
+                    dark:bg-[#0d1117] dark:border-border dark:text-green-300 dark:placeholder:text-text-muted
+                    bg-gray-900 border border-gray-700 text-green-400 placeholder:text-gray-500
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                  spellCheck={false}
+                />
+                <VoiceInput
+                  value={inputs[input.id] || ""}
+                  onChange={(v) => updateInput(input.id, v)}
+                  className="top-2 right-2"
+                />
+              </div>
+            )}
+
+            {input.type === "select" && (
               <select
-                value={inputs[input.id] || input.defaultValue || ''}
+                value={inputs[input.id] || input.defaultValue || ""}
                 onChange={(e) => updateInput(input.id, e.target.value)}
                 className="h-9 px-3 rounded-md text-sm cursor-pointer transition-colors
                   dark:bg-surface-input dark:border-border dark:text-text-primary
@@ -362,28 +382,32 @@ export default function AgentRunner({ agent }) {
                   focus:ring-1 focus:ring-accent focus:border-accent outline-none"
               >
                 {input.options?.map((opt) => (
-                  <option key={opt} value={opt}>{opt}</option>
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
                 ))}
               </select>
             )}
 
-            {input.type === 'multiselect' && (
+            {input.type === "multiselect" && (
               <div className="flex flex-wrap gap-2">
                 {input.options?.map((opt) => {
-                  const selected = (inputs[input.id] || []).includes(opt)
+                  const selected = (inputs[input.id] || []).includes(opt);
                   return (
                     <button
                       key={opt}
                       onClick={() => toggleMultiselect(input.id, opt)}
                       className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all border
-                        ${selected
-                          ? 'bg-accent/15 text-accent border-accent/30'
-                          : 'dark:bg-surface-input dark:text-text-secondary dark:border-border dark:hover:border-accent/30 bg-gray-50 text-gray-500 border-gray-200 hover:border-indigo-300'
+                        ${
+                          selected
+                            ? "bg-accent/15 text-accent border-accent/30"
+                            : "dark:bg-surface-input dark:text-text-secondary dark:border-border dark:hover:border-accent/30 bg-gray-50 text-gray-500 border-gray-200 hover:border-indigo-300"
                         }`}
                     >
-                      {selected && '✓ '}{opt}
+                      {selected && "✓ "}
+                      {opt}
                     </button>
-                  )
+                  );
                 })}
               </div>
             )}
@@ -401,8 +425,10 @@ export default function AgentRunner({ agent }) {
       </div>
 
       {/* Prompt Playground */}
-      <div className="mb-4 rounded-lg border transition-all duration-200
-        dark:bg-surface-card dark:border-border bg-white border-gray-200">
+      <div
+        className="mb-4 rounded-lg border transition-all duration-200
+        dark:bg-surface-card dark:border-border bg-white border-gray-200"
+      >
         <button
           onClick={() => setPlaygroundOpen(!playgroundOpen)}
           className="w-full flex items-center justify-between px-4 py-3 text-left group"
@@ -413,20 +439,29 @@ export default function AgentRunner({ agent }) {
               Prompt Playground
             </span>
             {isPromptModified && (
-              <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full
-                bg-amber-400/10 text-amber-500 border border-amber-400/20">
+              <span
+                className="text-[10px] font-medium px-1.5 py-0.5 rounded-full
+                bg-amber-400/10 text-amber-500 border border-amber-400/20"
+              >
                 Modified
               </span>
             )}
           </div>
           <div className="flex items-center gap-2">
             <span className="text-[10px] dark:text-text-muted text-gray-400">
-              {playgroundOpen ? 'Collapse' : 'Edit system prompt'}
+              {playgroundOpen ? "Collapse" : "Edit system prompt"}
             </span>
-            {playgroundOpen
-              ? <ChevronDown size={14} className="dark:text-text-muted text-gray-400 transition-transform" />
-              : <ChevronRight size={14} className="dark:text-text-muted text-gray-400 transition-transform" />
-            }
+            {playgroundOpen ? (
+              <ChevronDown
+                size={14}
+                className="dark:text-text-muted text-gray-400 transition-transform"
+              />
+            ) : (
+              <ChevronRight
+                size={14}
+                className="dark:text-text-muted text-gray-400 transition-transform"
+              />
+            )}
           </div>
         </button>
 
@@ -452,18 +487,24 @@ export default function AgentRunner({ agent }) {
                 )}
               </div>
             </div>
-            <textarea
-              value={customPrompt}
-              onChange={(e) => setCustomPrompt(e.target.value)}
-              onKeyDown={handleKeyDown}
-              rows={10}
-              spellCheck={false}
-              className="w-full px-3 py-2.5 rounded-lg text-xs font-mono leading-relaxed transition-colors resize-y
-                dark:bg-[#0d1117] dark:border-border dark:text-gray-300 dark:placeholder:text-text-muted
-                bg-gray-50 border border-gray-200 text-gray-700 placeholder:text-gray-400
-                focus:ring-1 focus:ring-accent focus:border-accent outline-none"
-              placeholder="Enter your custom system prompt..."
-            />
+            <div className="relative">
+              <textarea
+                value={customPrompt}
+                onChange={(e) => setCustomPrompt(e.target.value)}
+                rows={10}
+                spellCheck={false}
+                className="w-full pl-3 pr-10 py-2.5 rounded-lg text-xs font-mono leading-relaxed transition-colors resize-y
+                  dark:bg-[#0d1117] dark:border-border dark:text-gray-300 dark:placeholder:text-text-muted
+                  bg-gray-50 border border-gray-200 text-gray-700 placeholder:text-gray-400
+                  focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                placeholder="Enter your custom system prompt..."
+              />
+              <VoiceInput
+                value={customPrompt}
+                onChange={(v) => setCustomPrompt(v)}
+                className="top-2 right-2"
+              />
+            </div>
             {isPromptModified && (
               <p className="mt-2 text-[10px] dark:text-amber-400/80 text-amber-600 flex items-center gap-1">
                 <Sparkles size={10} />
@@ -488,7 +529,6 @@ export default function AgentRunner({ agent }) {
           </button>
         ) : (
           <button
-            ref={runButtonRef}
             onClick={handleRun}
             disabled={!canRun()}
             className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white
@@ -526,7 +566,9 @@ export default function AgentRunner({ agent }) {
         <div className="rounded-lg border p-6 dark:bg-surface-card dark:border-border bg-white border-gray-200 text-center animate-fade-in">
           <div className="flex items-center justify-center gap-2 mb-2">
             <Loader2 size={16} className="animate-spin text-accent" />
-            <span className="text-xs font-medium text-accent">Connecting to API...</span>
+            <span className="text-xs font-medium text-accent">
+              Connecting to API...
+            </span>
           </div>
           <p className="text-sm dark:text-text-secondary text-gray-500 transition-all duration-500">
             {LOADING_MESSAGES[msgIndex]}
@@ -568,5 +610,5 @@ export default function AgentRunner({ agent }) {
         />
       )}
     </div>
-  )
+  );
 }

--- a/src/components/VoiceInput.jsx
+++ b/src/components/VoiceInput.jsx
@@ -1,0 +1,162 @@
+import { useState, useEffect, useRef } from "react";
+import { Mic } from "lucide-react";
+
+/**
+ * VoiceInput — a mic button that uses the browser-native SpeechRecognition API
+ * to transcribe speech into a text/textarea field.
+ *
+ * Renders nothing on browsers without SpeechRecognition support (e.g. Firefox).
+ * Speech is appended to whatever was already in the field, so keyboard input
+ * and dictation can be mixed freely.
+ *
+ * Props:
+ *   value     — current value of the input field (string)
+ *   onChange  — called with the new value (string) when speech is transcribed
+ *   disabled  — optional, disables the mic button
+ *   className — optional extra classes for positioning
+ */
+export default function VoiceInput({
+  value,
+  onChange,
+  disabled = false,
+  className = "",
+}) {
+  // Feature-detect once. If unsupported, the component renders null below.
+  const SpeechRecognition =
+    typeof window !== "undefined" &&
+    (window.SpeechRecognition || window.webkitSpeechRecognition);
+
+  const [isRecording, setIsRecording] = useState(false);
+  const recognitionRef = useRef(null);
+  // Snapshot of `value` at the moment recording started, so onresult appends
+  // to a stable baseline instead of stale closure state.
+  const baseValueRef = useRef("");
+  // Latest onChange — keeps the recognition handlers from going stale.
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  // Cleanup: if the component unmounts mid-recording, stop the mic.
+  useEffect(() => {
+    return () => {
+      if (recognitionRef.current) {
+        try {
+          recognitionRef.current.stop();
+        } catch {
+          // ignore — already stopped
+        }
+      }
+    };
+  }, []);
+
+  if (!SpeechRecognition) {
+    return null;
+  }
+
+  const startRecording = () => {
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    baseValueRef.current = value || "";
+
+    recognition.onresult = (event) => {
+      let finalTranscript = "";
+      let interimTranscript = "";
+
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          finalTranscript += transcript;
+        } else {
+          interimTranscript += transcript;
+        }
+      }
+
+      // Persist finalized transcript into the baseline so the next event
+      // doesn't overwrite it with only interim results.
+      if (finalTranscript) {
+        const sep =
+          baseValueRef.current && !baseValueRef.current.endsWith(" ")
+            ? " "
+            : "";
+        baseValueRef.current =
+          baseValueRef.current + sep + finalTranscript.trim();
+      }
+
+      const sep =
+        baseValueRef.current &&
+        interimTranscript &&
+        !baseValueRef.current.endsWith(" ")
+          ? " "
+          : "";
+      onChangeRef.current(baseValueRef.current + sep + interimTranscript);
+    };
+
+    recognition.onerror = () => {
+      setIsRecording(false);
+      recognitionRef.current = null;
+    };
+
+    recognition.onend = () => {
+      setIsRecording(false);
+      recognitionRef.current = null;
+    };
+
+    try {
+      recognition.start();
+      recognitionRef.current = recognition;
+      setIsRecording(true);
+    } catch {
+      // start() throws if called while already running — safe to ignore.
+      setIsRecording(false);
+    }
+  };
+
+  const stopRecording = () => {
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.stop();
+      } catch {
+        // ignore
+      }
+    }
+    setIsRecording(false);
+  };
+
+  const handleClick = (e) => {
+    // Prevent button from submitting forms or stealing focus from the input.
+    e.preventDefault();
+    if (isRecording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      title={isRecording ? "Stop recording" : "Start voice input"}
+      aria-label={isRecording ? "Stop voice input" : "Start voice input"}
+      className={`absolute z-10 flex items-center justify-center w-7 h-7 rounded-md transition-colors
+        ${
+          isRecording
+            ? "text-red-500 bg-red-500/10 hover:bg-red-500/20"
+            : "text-gray-400 hover:text-accent hover:bg-accent/10 dark:text-text-muted"
+        }
+        disabled:opacity-40 disabled:cursor-not-allowed
+        ${className}`}
+    >
+      {isRecording && (
+        <span className="absolute inline-flex h-full w-full rounded-md bg-red-500/30 animate-ping" />
+      )}
+      <Mic size={14} className="relative" />
+    </button>
+  );
+}

--- a/src/components/VoiceInput.jsx
+++ b/src/components/VoiceInput.jsx
@@ -28,15 +28,32 @@ export default function VoiceInput({
 
   const [isRecording, setIsRecording] = useState(false);
   const recognitionRef = useRef(null);
-  // Snapshot of `value` at the moment recording started, so onresult appends
-  // to a stable baseline instead of stale closure state.
+  // Snapshot of `value` at the moment recording started. Each onresult event
+  // appends the latest transcript to this baseline. We update it in two cases:
+  //   1. When the speech engine finalizes a chunk (push it onto the baseline).
+  //   2. When the user types while recording (reconcile via lastWrittenRef
+  //      below) so their typing doesn't get clobbered by the next onresult.
   const baseValueRef = useRef("");
+  // The exact string we last pushed via onChange. If the incoming `value`
+  // prop diverges from this while recording, the user typed — and we need
+  // to fold their edit into the baseline.
+  const lastWrittenRef = useRef("");
   // Latest onChange — keeps the recognition handlers from going stale.
   const onChangeRef = useRef(onChange);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  // Reconcile user typing during recording. If `value` no longer matches
+  // what we last wrote, the user edited the field by hand — make their
+  // version the new baseline so the next transcript appends to it.
+  useEffect(() => {
+    if (isRecording && value !== lastWrittenRef.current) {
+      baseValueRef.current = value || "";
+      lastWrittenRef.current = value || "";
+    }
+  }, [value, isRecording]);
 
   // Cleanup: if the component unmounts mid-recording, stop the mic.
   useEffect(() => {
@@ -62,6 +79,7 @@ export default function VoiceInput({
     recognition.lang = "en-US";
 
     baseValueRef.current = value || "";
+    lastWrittenRef.current = value || "";
 
     recognition.onresult = (event) => {
       let finalTranscript = "";
@@ -87,13 +105,18 @@ export default function VoiceInput({
           baseValueRef.current + sep + finalTranscript.trim();
       }
 
+      // Trim interim too — Chrome's SpeechRecognition often returns
+      // transcripts with leading spaces ("word boundary" markers). Without
+      // trimming, you get a leading space on the very first utterance and
+      // double spaces between utterances.
+      const interim = interimTranscript.trim();
       const sep =
-        baseValueRef.current &&
-        interimTranscript &&
-        !baseValueRef.current.endsWith(" ")
+        baseValueRef.current && interim && !baseValueRef.current.endsWith(" ")
           ? " "
           : "";
-      onChangeRef.current(baseValueRef.current + sep + interimTranscript);
+      const next = baseValueRef.current + sep + interim;
+      lastWrittenRef.current = next;
+      onChangeRef.current(next);
     };
 
     recognition.onerror = () => {


### PR DESCRIPTION
Closes #23 

## Summary

Adds a microphone button to every text and textarea field in the agent runner, letting users dictate input instead of typing. Uses the browser-native `SpeechRecognition` API — no backend, no API key, no new dependencies, no cost.

## What's new

- **`src/components/VoiceInput.jsx`** — new reusable mic button component
- **`src/components/AgentRunner.jsx`** — wires the button into all four dictatable fields (text, textarea, code, and the Prompt Playground system prompt)

## How it works

- Click the mic to start recording, click again to stop
- Live transcription appears in the field as you speak (uses `interimResults`)
- Speech appends to whatever's already in the field, so you can mix typing and dictation freely
- Pulsing red indicator while active, idle gray otherwise
- On unsupported browsers (Firefox), the button renders `null` — gracefully hidden, not broken

## Implementation notes

- Feature-detected via `window.SpeechRecognition || window.webkitSpeechRecognition`
- Base value snapshotted in a ref at record-start so each `onresult` event appends to a stable baseline instead of fighting stale closure state
- `onend` and `onerror` both reset the recording flag, covering browser auto-stop and permission denials
- Unmount cleanup stops any live recognition to prevent mic leaks when navigating away
- Existing `value` / `onChange` flow is untouched — speech calls the same `updateInput` / `setCustomPrompt` that typing does, so keyboard input behavior is unchanged

## Visual placement

- Single-line `text` inputs: vertically centered, right side
- Textareas (`textarea`, `code`, prompt playground): top-right corner (avoids colliding with the `resize-y` handle in the bottom-right)
- Right padding bumped to `pr-10` so text never slides under the icon