### PR TITLE
Add recently used agents section

### DIFF
--- a/src/pages/AgentPage.jsx
+++ b/src/pages/AgentPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useParams, Navigate } from 'react-router-dom'
 import agents from '../agents/registry'
 import AgentRunner from '../components/AgentRunner'
@@ -5,6 +6,24 @@ import AgentRunner from '../components/AgentRunner'
 export default function AgentPage() {
   const { id } = useParams()
   const agent = agents.find((a) => a.id === id)
+
+  useEffect(() => {
+    if (!agent) return
+
+    const existing = JSON.parse(
+      localStorage.getItem('recentAgents') || '[]'
+    )
+
+    const updated = [
+      agent.id,
+      ...existing.filter((item) => item !== agent.id),
+    ].slice(0, 5)
+
+    localStorage.setItem(
+      'recentAgents',
+      JSON.stringify(updated)
+    )
+  }, [agent])
 
   if (!agent) {
     return <Navigate to="/" replace />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -26,7 +26,18 @@ const defaultMeta = { color: 'from-gray-500 to-gray-400', ring: 'ring-gray-500/3
 export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(null)
+  
   const { favorites } = useFavorites()
+
+const recentAgents = useMemo(() => {
+  const recentIds = JSON.parse(
+    localStorage.getItem('recentAgents') || '[]'
+  )
+
+  return recentIds
+    .map((id) => agents.find((a) => a.id === id))
+    .filter(Boolean)
+}, [])
 
   // Resolve favorite agents (preserving the user's star order)
   const favoriteAgents = useMemo(() => {
@@ -133,6 +144,34 @@ export default function HomePage() {
           </div>
         </div>
       )}
+      {/* ── Recently Used Section ── */}
+{recentAgents.length > 0 && !showingFiltered && (
+  <div className="mb-8 animate-fade-in">
+    <div className="flex items-center gap-2 mb-4">
+      <Heart size={14} className="text-pink-400 fill-pink-400" />
+
+      <h2 className="text-sm font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
+        Recently Used
+      </h2>
+
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-pink-400/10 text-pink-500 border border-pink-400/20">
+        {recentAgents.length}
+      </span>
+    </div>
+
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {recentAgents.map((agent, idx) => (
+        <div
+          key={agent.id}
+          className="animate-fade-in"
+          style={{ animationDelay: `${idx * 40}ms` }}
+        >
+          <AgentCard agent={agent} />
+        </div>
+      ))}
+    </div>
+  </div>
+)}
 
       {/* ── Search & Category Filter Section ── */}
       <div className="mb-6 space-y-4">


### PR DESCRIPTION
## What does this PR do?

<!-- Tell me in one or two sentences what you changed and why. -->

## Type of change

Added tracking for recently opened agents using localStorage
Added a “Recently Used” section on the homepage
Preserved ordering based on most recently opened agents
Added persistence across refreshes

## Checklist

**For every PR:**
- [  ] I tested this locally with `npm run dev`
- [  ] No API keys are anywhere in my code
- [  ] I did not add any new packages without discussing it first

**For new agent PRs:**
- [  ] I tested the agent with a real API key
- [  ] I created a new file in `src/agents/definitions/` with the agent config
- [  ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [  ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [  ] The system prompt clearly describes the format of the output
- [  ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

> If you changed anything visual, drop a before and after screenshot here.
> It helps me review faster and see exactly what changed.
> Skip this if your PR has no visual changes.

**Before:**
<img width="1361" height="682" alt="Screenshot 2026-05-13 001400" src="https://github.com/user-attachments/assets/763e7801-c7f0-4572-ae6a-07fbccf8a834" />

**After:**

<
<img width="1363" height="645" alt="Screenshot 2026-05-13 001417" src="https://github.com/user-attachments/assets/2b7f6202-d3fb-44e5-b32f-7386ad515ddf" />

>

## Anything else I should know?
This PR implements the feature requested in issue #37.

The Recently Opened section is working and visible on localhost.

Closes #37

