### PR TITLE
feat: add Sales category to categories registry

### DIFF
--- a/src/agents/categories.js
+++ b/src/agents/categories.js
@@ -20,5 +20,6 @@ export const CATEGORIES = [
   "Product",
   "Productivity",
   "Research",
-  "Healthcare"
+  "Healthcare",
+  "Sales"
 ];


### PR DESCRIPTION
## What does this PR do?

Added `'Sales'` to the categories registry in `src/agents/categories.js`. This resolves the issue to add the new domain and unblocks the creation of future Sales-related agents.

## Type of change

- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [x] Something else (Configuration update to unblock new agents)

## Checklist

**For every PR:**
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

**Before:**
*(No visual changes on base load)*

**After:**
*(No visual changes on base load — see testing notes below)*

## Anything else I should know?

**Testing Notes:**
I verified this works locally by temporarily assigning the 'Sales' category to an existing agent (`cold-email-writer.js`) and confirming the "Sales" pill successfully populated and filtered on the homepage UI. I reverted the agent file back to its original state before committing.

** Developer Note (Local Setup Issue):**
Just a heads up: on a fresh clone, the local dev server crashes because `supabase.js` expects environment variables for the new Workflows feature, but the README states no `.env` is needed. I bypassed this locally by creating a `.env` with dummy `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` values to test this change. You might want to add a fallback in the code or update the README for future contributors!

Resolves #41 