### PR TITLE
Add log analysis summarizer agent

### DIFF
--- a/src/agents/definitions/log-analysis-summarizer.js
+++ b/src/agents/definitions/log-analysis-summarizer.js
@@ -1,0 +1,105 @@
+export default {
+  id: "log-analysis-summarizer",
+  createdAt: "2025-05-14",
+  name: "Log Analysis Summarizer",
+  description:
+    "Paste raw application, infrastructure, or deployment logs and get a structured summary of the errors, warnings, event timeline, patterns, and likely root cause.",
+  category: "Engineering",
+  icon: "FileSearch",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    logs:
+      "2026-05-14T09:13:02Z INFO api boot completed\n2026-05-14T09:14:18Z WARN db connection pool at 95% usage\n2026-05-14T09:14:31Z ERROR checkout POST /orders failed request_id=req_7f2 timeout waiting for database connection\n2026-05-14T09:15:04Z ERROR worker retry exhausted job=charge-card order_id=ord_291\n2026-05-14T09:16:10Z INFO rollback started release=2026.05.14.2\n2026-05-14T09:18:42Z INFO error rate returned to baseline",
+    systemContext:
+      "Node.js checkout API running behind Kubernetes with a Postgres database and background payment worker.",
+    analysisGoal: "Find the likely root cause and the log lines that matter most.",
+    outputDepth: "Detailed",
+  },
+  inputs: [
+    {
+      id: "logs",
+      label: "Raw logs",
+      type: "textarea",
+      placeholder:
+        "Paste the application, server, build, or infrastructure logs you want analyzed. Include timestamps and surrounding context when possible.",
+      required: true,
+    },
+    {
+      id: "systemContext",
+      label: "System or incident context (optional)",
+      type: "textarea",
+      placeholder:
+        "e.g. Checkout API on Kubernetes, Postgres database, errors started after the latest deployment.",
+    },
+    {
+      id: "analysisGoal",
+      label: "What are you trying to find?",
+      type: "text",
+      placeholder:
+        "e.g. Root cause, suspicious errors, deployment regression, performance bottleneck",
+    },
+    {
+      id: "outputDepth",
+      label: "Summary depth",
+      type: "select",
+      options: ["Concise", "Detailed", "For incident report"],
+      defaultValue: "Detailed",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a senior DevOps and site reliability engineer who can
+read noisy logs quickly and explain what actually matters.
+
+Analyze the provided logs carefully. Do not invent services, timestamps, or
+causes that are not supported by the evidence. If the logs are incomplete, say
+what is missing and how confident you are.
+
+Always respond in this exact format:
+
+## Log Analysis Summary
+
+### Executive Summary
+2-4 sentences describing what happened, the affected component if inferable,
+and the most likely failure mode.
+
+### Key Findings
+| Severity | Evidence | Meaning |
+|----------|----------|---------|
+| Error/Warning/Info | [quote the exact relevant log line or compact excerpt] | [why it matters] |
+
+### Timeline of Events
+| Time | Event |
+|------|-------|
+| [timestamp or order] | [normalized event description] |
+
+### Error and Warning Breakdown
+- Errors: [count or grouped summary of distinct errors]
+- Warnings: [count or grouped summary of distinct warnings]
+- Repeated patterns: [recurring request ids, endpoints, services, jobs, hosts, or stack frames]
+
+### Likely Root Cause
+State the most likely root cause and cite the specific log evidence. Include a
+confidence level: High, Medium, or Low.
+
+### The 5 Lines That Matter Most
+1. [exact log line or shortest useful excerpt]
+2. [exact log line or shortest useful excerpt]
+3. [exact log line or shortest useful excerpt]
+4. [exact log line or shortest useful excerpt]
+5. [exact log line or shortest useful excerpt]
+
+### Recommended Next Steps
+- [specific diagnostic or remediation step]
+- [specific diagnostic or remediation step]
+- [specific diagnostic or remediation step]
+
+Rules:
+- Preserve exact timestamps, request IDs, service names, and error messages
+- Separate confirmed facts from hypotheses
+- Prioritize causal sequences over noisy repeated lines
+- If stack traces are present, identify the top application frame
+- If the input contains sensitive tokens or secrets, warn the user and avoid repeating them in full`,
+  outputType: "markdown",
+};


### PR DESCRIPTION
## What does this PR do?

Adds a Log Analysis Summarizer agent that turns raw log output into a structured incident-style summary with key findings, timeline, error/warning breakdown, likely root cause, and recommended next steps. This addresses #65 by adding the requested DevOps-focused agent as a standalone definition.

## Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [ ] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

**Before:**

N/A

**After:**

N/A

## Anything else I should know?

Verification run: `npm run build` completed successfully. I did not run the local dev server or test with a real API key in this environment.
