### PR TITLE
Add follow-up email sequence writer agent

### DIFF
--- a/src/agents/definitions/follow-up-email-sequence-writer.js
+++ b/src/agents/definitions/follow-up-email-sequence-writer.js
@@ -1,0 +1,102 @@
+export default {
+  id: "follow-up-email-sequence-writer",
+  createdAt: "2026-05-14",
+  name: "Follow-Up Email Sequence Writer",
+  description:
+    "Create a two-week, five-email follow-up sequence with varied angles and ready-to-send subject lines.",
+  category: "Sales",
+  icon: "MailPlus",
+  provider: "any",
+  defaultProvider: "openai",
+  model: "gpt-4o-mini",
+  exampleInputs: {
+    product:
+      "PipelineIQ - a revenue intelligence platform that flags stalled deals and recommends next-best actions for account executives.",
+    prospectSituation:
+      "VP of Sales at a 120-person SaaS company. They liked the first demo but need to align with RevOps before moving forward.",
+    lastInteraction:
+      "Discovery call ended with interest in a pilot, but the prospect asked for time to compare reporting needs with their current CRM dashboards.",
+    desiredOutcome: "Book a 30-minute pilot planning call",
+    tone: "Consultative",
+  },
+  inputs: [
+    {
+      id: "product",
+      label: "Product or offer",
+      type: "textarea",
+      placeholder: "Describe what you sell and the main value proposition...",
+      required: true,
+    },
+    {
+      id: "prospectSituation",
+      label: "Prospect situation",
+      type: "textarea",
+      placeholder:
+        "Who is the prospect, what do they care about, and where are they in the buying process?",
+      required: true,
+    },
+    {
+      id: "lastInteraction",
+      label: "Last interaction",
+      type: "textarea",
+      placeholder:
+        "Summarize the last call, reply, objection, demo, or meeting notes...",
+      required: true,
+    },
+    {
+      id: "desiredOutcome",
+      label: "Desired outcome",
+      type: "text",
+      placeholder: "e.g. Schedule a demo, get budget approval, revive the conversation",
+      required: true,
+    },
+    {
+      id: "tone",
+      label: "Tone",
+      type: "select",
+      options: ["Consultative", "Friendly", "Direct", "Executive"],
+      defaultValue: "Consultative",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are an expert sales follow-up strategist.
+Create a practical five-email follow-up sequence for the product, prospect situation, last interaction, desired outcome, and tone provided.
+
+Output in this exact format:
+
+## Follow-Up Sequence
+
+### Email 1 — Day 1: [angle]
+**Subject:** [subject line]
+**Body:**
+[ready-to-send email]
+
+### Email 2 — Day 3: [angle]
+**Subject:** [subject line]
+**Body:**
+[ready-to-send email]
+
+### Email 3 — Day 6: [angle]
+**Subject:** [subject line]
+**Body:**
+[ready-to-send email]
+
+### Email 4 — Day 10: [angle]
+**Subject:** [subject line]
+**Body:**
+[ready-to-send email]
+
+### Email 5 — Day 14: [angle]
+**Subject:** [subject line]
+**Body:**
+[ready-to-send email]
+
+Rules:
+- Use a different angle for every email, such as recap, business case, social proof, helpful resource, and polite breakup.
+- Keep each email under 120 words.
+- Personalize around the prospect situation and last interaction.
+- Include one clear call to action tied to the desired outcome.
+- Do not use pushy, guilt-based, or manipulative language.
+- Do not add explanations outside the requested sequence.`,
+  outputType: "markdown",
+};


### PR DESCRIPTION
## What does this PR do?

Adds a Sales-domain follow-up email sequence writer agent that turns product context, the prospect situation, and the last interaction into a five-email cadence with subject lines over two weeks. The prompt keeps each email concise, varies the angle across the sequence, and ties the CTA to the user's desired outcome.

## Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [ ] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #76
- [ ] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

No UI layout changes.

## Anything else I should know?

Verified with a definition import smoke check, a lucide icon assertion, `npm run build`, and `git diff --check`. `npm ci` reported existing audit warnings, but no packages were added or changed in this PR.

Closes #76
