### PR TITLE
fix(ui): prevent invisible text on model select dropdown options (#137)Fix/model dropdown UI

### DIFF
--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -103,7 +103,7 @@ export default function ApiKeyBar({
             focus:ring-1 focus:ring-accent focus:border-accent outline-none"
         >
           {availableModels.map((m) => (
-            <option key={m.value} value={m.value}>
+            <option key={m.value} value={m.value} className="text-black">
               {m.label}
             </option>
           ))}


### PR DESCRIPTION
## Description
Closes #137 

This PR fixes a critical UI bug where the model selector dropdown rendered white text on a white background, making the options completely invisible until hovered over.

### Changes:
- **`src/components/ApiKeyBar.jsx`**: Added `className="text-black"` to the `<option>` tags inside the model `<select>`. This forces the text to remain legible against the native OS dropdown background and prevents it from improperly inheriting `dark:text-white`.

### Testing
- [x] Verified locally. Options are now fully legible and visible before hovering.
