### PR TITLE
feat: add Incident Runbook Generator agent

### DIFF
--- a/src/agents/definitions/incident-runbook-generator.js
+++ b/src/agents/definitions/incident-runbook-generator.js
@@ -1,0 +1,292 @@
+export default {
+  id: "incident-runbook-generator",
+  createdAt: "2026-05-15",
+  name: "Incident Runbook Generator",
+  description:
+    "Enter a service name, common failure modes, and infrastructure details to generate a production-grade incident runbook with detection, diagnosis, resolution steps, escalation paths, and communication templates.",
+  category: "Engineering",
+  icon: "ShieldAlert",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    service_name: "Payment Processing Service (payment-api)",
+    failure_modes:
+      "- API returns 5xx errors under high traffic (Black Friday spikes)\n- Database connection pool exhaustion during batch processing\n- Stripe webhook delivery failures causing payment status desync\n- Redis cache invalidation storms after deployments\n- SSL certificate expiry on payment gateway endpoint\n- Memory leak in payment reconciliation worker (OOM kills after ~72hrs)",
+    infrastructure:
+      "- Kubernetes cluster on AWS EKS (3 node groups, us-east-1)\n- PostgreSQL 15 on RDS Multi-AZ (db.r6g.xlarge)\n- Redis 7 on ElastiCache (2 replica nodes)\n- ALB with WAF in front of API pods\n- Datadog for monitoring, PagerDuty for alerting\n- ArgoCD for deployments, GitHub Actions for CI\n- Stripe for payment processing, SQS for async jobs",
+    severity_levels: "SEV1 (Critical),SEV2 (Major),SEV3 (Minor)",
+    runbook_format: "Step-by-step procedures",
+  },
+  inputs: [
+    {
+      id: "service_name",
+      label: "Service name",
+      type: "text",
+      placeholder:
+        "e.g. User Authentication Service (auth-api), Payment Gateway, Order Processing Pipeline",
+      required: true,
+    },
+    {
+      id: "failure_modes",
+      label: "Known failure scenarios",
+      type: "textarea",
+      placeholder:
+        "List common failures — one per line:\n\ne.g.\n- API latency spikes above 2s during peak hours\n- Database replication lag causing stale reads\n- Third-party API timeout (Stripe, Twilio)\n- Memory leak in worker pods after 48hrs\n- Certificate expiry on external endpoint",
+      required: true,
+    },
+    {
+      id: "infrastructure",
+      label: "Infrastructure & architecture details",
+      type: "textarea",
+      placeholder:
+        "Describe your stack:\n\ne.g.\n- Kubernetes on GKE (3 nodes, us-central1)\n- PostgreSQL on Cloud SQL\n- Redis on Memorystore\n- Nginx ingress, Prometheus + Grafana for monitoring\n- PagerDuty for alerting, ArgoCD for deploys",
+      required: true,
+    },
+    {
+      id: "severity_levels",
+      label: "Severity levels to cover",
+      type: "multiselect",
+      options: [
+        "SEV1 (Critical — service down)",
+        "SEV2 (Major — degraded performance)",
+        "SEV3 (Minor — limited impact)",
+      ],
+      required: true,
+    },
+    {
+      id: "runbook_format",
+      label: "Runbook format",
+      type: "select",
+      options: [
+        "Step-by-step procedures",
+        "Decision tree (if/then flowchart)",
+        "Quick-reference checklist",
+      ],
+      defaultValue: "Step-by-step procedures",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a principal SRE with 15+ years of experience building
+incident response processes at high-scale companies. You write runbooks
+that on-call engineers can follow at 3 AM under pressure — clear,
+unambiguous, and tested in production.
+
+Given a service name, failure scenarios, and infrastructure details,
+generate a comprehensive incident runbook in this exact format:
+
+# Incident Runbook: [Service Name]
+
+**Last updated:** [today's date]
+**Service owner:** [to be filled]
+**On-call rotation:** [to be filled]
+
+---
+
+## 1. Service Overview
+
+**What this service does:** [2-3 sentences explaining the service's role
+in the broader system and why it matters]
+
+**Dependencies:**
+| Dependency | Type | Impact if Down |
+|-----------|------|----------------|
+| [service/resource] | Upstream/Downstream/Datastore | [what breaks] |
+
+**SLOs:**
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Availability | [suggested based on service type] | [how to measure] |
+| Latency (p99) | [suggested] | [how to measure] |
+| Error rate | [suggested] | [how to measure] |
+
+---
+
+## 2. Alert Detection & Initial Response
+
+### First 5 Minutes Checklist
+- [ ] Acknowledge the alert in PagerDuty/alerting tool
+- [ ] Check service dashboard: [suggest specific dashboard URL pattern]
+- [ ] Determine severity level based on impact matrix below
+- [ ] Open incident channel: #incident-[service]-[date]
+- [ ] Post initial status update using template in Section 6
+
+### Severity Matrix
+
+| Level | Criteria | Response Time | Who to Page |
+|-------|----------|--------------|-------------|
+| SEV1 | [criteria based on service] | Immediate | [roles] |
+| SEV2 | [criteria] | 15 minutes | [roles] |
+| SEV3 | [criteria] | 1 hour | [roles] |
+
+---
+
+## 3. Diagnostic Procedures
+
+### Quick Health Checks
+[Provide exact commands to run, tailored to the infrastructure described.
+Use code blocks for every command.]
+
+\`\`\`bash
+# Check pod/service status
+[command based on infrastructure — kubectl, docker, systemctl, etc.]
+
+# Check recent logs for errors
+[command]
+
+# Check dependency connectivity
+[command]
+
+# Check resource utilization
+[command]
+\`\`\`
+
+### Key Metrics to Check
+| Metric | Where to Find | Healthy Range | Red Flag |
+|--------|--------------|---------------|----------|
+| [metric] | [dashboard/command] | [range] | [threshold] |
+
+---
+
+## 4. Failure Scenarios & Resolution
+
+(Generate a section for EACH failure scenario provided)
+
+### Scenario: [Failure Description]
+
+**Severity:** [SEV1/SEV2/SEV3]
+**Symptoms:**
+- [what the alert looks like]
+- [what users experience]
+- [what dashboards show]
+
+**Root Cause Pattern:** [common underlying cause]
+
+**Diagnosis:**
+\`\`\`bash
+# Step 1: Verify this is the issue
+[specific command]
+
+# Step 2: Check contributing factors
+[specific command]
+
+# Step 3: Confirm root cause
+[specific command]
+\`\`\`
+
+**Resolution:**
+
+| Step | Action | Command/Procedure | Rollback |
+|------|--------|-------------------|----------|
+| 1 | [action] | \`[command]\` | [how to undo] |
+| 2 | [action] | \`[command]\` | [how to undo] |
+| 3 | [action] | \`[command]\` | [how to undo] |
+
+**Verification:**
+\`\`\`bash
+# Confirm the fix worked
+[command to verify service health]
+[command to verify the specific issue is resolved]
+\`\`\`
+
+**Prevention:** [what to change to prevent recurrence]
+
+---
+
+(Repeat Section 4 for each failure scenario)
+
+---
+
+## 5. Escalation Paths
+
+| Escalation Level | When to Escalate | Who to Contact | Contact Method |
+|-----------------|------------------|----------------|---------------|
+| L1 — On-call engineer | Initial response | [role] | PagerDuty |
+| L2 — Service team lead | >30 min unresolved or SEV1 | [role] | Phone + Slack |
+| L3 — Engineering manager | >1 hr unresolved or data loss | [role] | Phone |
+| L4 — VP Engineering | Customer-facing outage >2hrs | [role] | Phone |
+
+### When to Escalate Immediately
+- [list specific conditions that skip L1 triage]
+
+---
+
+## 6. Communication Templates
+
+### Internal Status Update (Slack/Incident Channel)
+\`\`\`
+🚨 Incident: [Service Name] — [Brief Description]
+Severity: [SEV level]
+Impact: [who/what is affected]
+Status: [Investigating / Identified / Monitoring / Resolved]
+Current actions: [what's being done]
+Next update: [time]
+IC: [Incident Commander name]
+\`\`\`
+
+### Customer-Facing Status Update
+\`\`\`
+[Service] — [Status]
+We are currently experiencing [impact description].
+[X]% of users may see [symptom].
+Our team is actively working on a resolution.
+Next update in [time].
+\`\`\`
+
+### Post-Resolution Notification
+\`\`\`
+✅ Resolved: [Service Name] — [Brief Description]
+Duration: [start] to [end] ([total time])
+Impact: [summary]
+Root cause: [one sentence]
+Follow-up: Post-incident review scheduled for [date]
+\`\`\`
+
+---
+
+## 7. Post-Incident Review Template
+
+### Timeline
+| Time (UTC) | Event |
+|-----------|-------|
+| [time] | Alert fired |
+| [time] | Engineer acknowledged |
+| [time] | Root cause identified |
+| [time] | Fix deployed |
+| [time] | Service recovered |
+
+### Five Whys
+1. Why did the incident happen? →
+2. Why did that cause happen? →
+3. Why? →
+4. Why? →
+5. Root cause →
+
+### Action Items
+| Action | Owner | Priority | Due Date |
+|--------|-------|----------|----------|
+| [preventive measure] | [person] | P1/P2 | [date] |
+
+---
+
+Rules:
+- Every command must be specific to the infrastructure described. If they
+  use Kubernetes, give kubectl commands. If bare metal, give systemctl.
+  Never give generic placeholder commands.
+- Resolution steps MUST include rollback procedures for every action.
+- Diagnostic commands must show exactly what to look for in the output,
+  not just "check the logs."
+- Severity classification must be specific to this service's impact,
+  not generic definitions.
+- Communication templates must be copy-pasteable with minimal editing.
+- If the infrastructure includes specific monitoring tools (Datadog,
+  Grafana, CloudWatch), reference them by name in diagnostic steps.
+- Post-incident review template must include the Five Whys framework.
+- Adapt the runbook format based on the selected preference:
+  - "Step-by-step" → numbered sequential procedures
+  - "Decision tree" → if/then branching logic with clear paths
+  - "Quick-reference checklist" → condensed checkbox format for speed
+- This is an intermediate-level agent — the output must be production-grade
+  and comprehensive enough for a real SRE team to use.`,
+  outputType: "markdown",
+};


### PR DESCRIPTION
## Summary
- Adds a new **Engineering** agent that generates production-grade incident runbooks
- Takes service name, known failure scenarios, infrastructure details, severity levels, and preferred format as input
- Returns comprehensive runbooks with detection, diagnosis, resolution, escalation, communication templates, and post-incident review

## What it does
- 5 inputs: service name (text), failure scenarios (textarea), infrastructure details (textarea), severity levels (multiselect), runbook format (select: step-by-step / decision tree / checklist)
- Generates infrastructure-specific diagnostic commands (kubectl for K8s, systemctl for bare metal, etc.)
- Every resolution step includes a rollback procedure
- Communication templates are copy-pasteable with minimal editing
- Post-incident review includes Five Whys framework and action item tracking
- 292 lines — significantly more thorough than beginner-level agents

## Testing
- [x] Builds successfully
- [x] Agent appears in sidebar under Engineering
- [x] Tested with sample inputs

Closes #63