### PR TITLE
feat: add Technical Debt Report Generator agent

### DIFF
--- a/src/agents/definitions/technical-debt-report-generator.js
+++ b/src/agents/definitions/technical-debt-report-generator.js
@@ -1,0 +1,68 @@
+export default {
+  id: "technical-debt-report-generator",
+  createdAt: "2026-05-16",
+  name: "Technical Debt Report Generator",
+  description:
+    "Generate structured technical debt reports with business impact,estimated effort to fix,risk if ignored and prioritized recommendations.",
+  category: "Engineering",
+  icon: "FileWarning",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+  codebaseProblems:
+    "React project with repeated code, outdated dependencies, and missing test coverage.",
+  projectType: "Web Application",
+  audience: "Product Manager",
+},
+inputs: [
+    {
+      id: "codebaseProblems",
+      label: "Current Codebase Problems",
+      type: "textarea",
+      placeholder: "Describe the technical debt or current software issues...",
+      required: true,
+    },
+    {
+      id: "projectType",
+      label: "Project Type",
+      type: "select",
+      options: [
+        "Web Application",
+        "Mobile App",
+        "Backend API",
+        "Microservices",
+        "Enterprise Software",
+      ],
+      defaultValue: "Web Application",
+      required: true,
+    },
+    {
+      id: "audience",
+      label: "Audience",
+      type: "select",
+      options: [
+        "Engineering Manager",
+        "Product Manager",
+        "CTO",
+        "Non-Technical Stakeholder",
+      ],
+      defaultValue: "Product Manager",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a senior software architect and technical debt analyst.
+
+Given details about a software project's current issues, generate a structured technical debt report suitable for both technical and non-technical stakeholders.
+
+Include:
+- Executive summary
+- Key technical debt issues
+- Business impact
+- Risk if ignored
+- Estimated effort to fix
+- Prioritized recommendations
+
+Keep the report professional, concise, and easy to understand.`,
+outputType:"text",
+};


### PR DESCRIPTION
 **What does this PR do?**

Adds a new AI agent called Technical Debt Report Generator that generates structured technical debt reports with business impact, estimated effort to fix, risk if ignored and prioritized recommendations.

 Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)
N/A

## Anything else I should know?
Focussed on keeping the report structure concise and highly informative for both technical and non-technical audience.
