### PR TITLE
fix: add bg-gray-900 and text-white to dropdown options for visibility

### DIFF
--- a/src/pages/BattleModeSetup.jsx
+++ b/src/pages/BattleModeSetup.jsx
@@ -15,7 +15,6 @@ export default function BattleModeSetup() {
     [selectedAgentId]
   )
 
-  // Initialize input defaults when agent changes
   const handleAgentChange = (agentId) => {
     setSelectedAgentId(agentId)
     const agent = agents.find((a) => a.id === agentId)
@@ -73,9 +72,9 @@ export default function BattleModeSetup() {
   }
 
   const keyFields = [
-    { id: 'openai',    label: 'OpenAI API Key',    color: 'yellow',  icon: Key, borderColor: 'border-yellow-400/30', focusColor: 'focus:ring-yellow-400/40 focus:border-yellow-400/50', focusBg: 'focus:bg-yellow-400/5' },
-    { id: 'anthropic', label: 'Anthropic API Key',  color: 'violet',  icon: Key, borderColor: 'border-violet-400/30', focusColor: 'focus:ring-violet-400/40 focus:border-violet-400/50', focusBg: 'focus:bg-violet-400/5' },
-    { id: 'gemini',    label: 'Google Gemini API Key', color: 'blue', icon: Key, borderColor: 'border-blue-400/30',   focusColor: 'focus:ring-blue-400/40 focus:border-blue-400/50', focusBg: 'focus:bg-blue-400/5' },
+    { id: 'openai',    label: 'OpenAI API Key',       color: 'yellow', icon: Key, borderColor: 'border-yellow-400/30', focusColor: 'focus:ring-yellow-400/40 focus:border-yellow-400/50', focusBg: 'focus:bg-yellow-400/5' },
+    { id: 'anthropic', label: 'Anthropic API Key',     color: 'violet', icon: Key, borderColor: 'border-violet-400/30', focusColor: 'focus:ring-violet-400/40 focus:border-violet-400/50', focusBg: 'focus:bg-violet-400/5' },
+    { id: 'gemini',    label: 'Google Gemini API Key', color: 'blue',   icon: Key, borderColor: 'border-blue-400/30',   focusColor: 'focus:ring-blue-400/40 focus:border-blue-400/50',   focusBg: 'focus:bg-blue-400/5' },
   ]
 
   return (
@@ -113,13 +112,15 @@ export default function BattleModeSetup() {
           <select
             value={selectedAgentId}
             onChange={(e) => handleAgentChange(e.target.value)}
-            className="w-full h-11 px-4 rounded-lg text-sm bg-gray-900/60 border border-gray-700/60
+            className="w-full h-11 px-4 rounded-lg text-sm bg-gray-900 border border-gray-700/60
               text-white cursor-pointer focus:ring-1 focus:ring-yellow-400/40 focus:border-yellow-400/50 
               outline-none hover:border-gray-600 transition-all duration-200 battle-select-highlight"
           >
-            <option value="">-- Choose an agent --</option>
+            <option value="" className="bg-gray-900 text-white">
+              -- Choose an agent --
+            </option>
             {agents.map((a) => (
-              <option key={a.id} value={a.id}>
+              <option key={a.id} value={a.id} className="bg-gray-900 text-white">
                 {a.name} ({a.category})
               </option>
             ))}
@@ -170,13 +171,13 @@ export default function BattleModeSetup() {
                   <select
                     value={inputs[input.id] || input.defaultValue || ''}
                     onChange={(e) => updateInput(input.id, e.target.value)}
-                    className="w-full h-10 px-4 rounded-lg text-sm bg-gray-900/60 border border-gray-700/60
+                    className="w-full h-10 px-4 rounded-lg text-sm bg-gray-900 border border-gray-700/60
                       text-white cursor-pointer hover:border-gray-600
-                      focus:ring-1 focus:ring-yellow-400/40 focus:border-yellow-400/50 focus:bg-gray-900/80
+                      focus:ring-1 focus:ring-yellow-400/40 focus:border-yellow-400/50 focus:bg-gray-900
                       outline-none transition-all duration-200"
                   >
                     {input.options?.map((opt) => (
-                      <option key={opt} value={opt}>{opt}</option>
+                      <option key={opt} value={opt} className="bg-gray-900 text-white">{opt}</option>
                     ))}
                   </select>
                 )}
@@ -211,7 +212,7 @@ export default function BattleModeSetup() {
           <h2 className="text-xs font-semibold text-gray-300 uppercase tracking-wider">
             API Keys
           </h2>
-          {keyFields.map((field, idx) => (
+          {keyFields.map((field) => (
             <div key={field.id}>
               <label className="block text-xs font-medium text-gray-200 mb-2">
                 {field.label}


### PR DESCRIPTION
## What does this PR do?

Fixed the Battle Setup agent selector dropdown where options were invisible due to missing background and text color styles on native HTML option elements.

## Type of change

- [x] Bug fix

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #150
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first


## Screenshots (optional — but really helpful for UI changes)

**Before:**

<img width="1919" height="908" alt="Screenshot 2026-05-16 122132" src="https://github.com/user-attachments/assets/0ec9417a-cb3e-428d-8a38-12b79a97a3c8" />

**After:**
<img width="1477" height="907" alt="image" src="https://github.com/user-attachments/assets/83564a86-f800-43a8-89b9-307b103fea6e" />

## Anything else I should know?

The dropdown used bg-gray-900/60 (semi-transparent) on the select element but native HTML option elements were inheriting the system white background. Fixed by adding bg-gray-900 and text-white to all option elements and hanging the select background to solid bg-gray-900.
