### PR TITLE
feat: add openrouter provider and supabase env fallback

### DIFF
--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -1,5 +1,5 @@
 /**
- * LLM Adapter — unified interface for calling OpenAI, Anthropic, and Gemini APIs
+ * LLM Adapter — unified interface for calling OpenAI, Anthropic, Gemini, and OpenRouter APIs
  * directly from the browser. No backend required.
  *
  * Supports both one-shot (`runAgent`) and streaming (`streamAgent`) modes.
@@ -139,6 +139,51 @@ const PROVIDER_CONFIGS = {
       }
     },
   },
+
+  openrouter: {
+    url: 'https://openrouter.ai/api/v1/chat/completions',
+    buildHeaders: (apiKey) => ({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'HTTP-Referer': window.location.origin,
+      'X-Title': document.title || 'iloveAgents',
+    }),
+    buildBody: (model, systemPrompt, userMessage) => ({
+      model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userMessage },
+      ],
+      max_tokens: 4096,
+    }),
+    buildStreamBody: (model, systemPrompt, userMessage) => ({
+      model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userMessage },
+      ],
+      max_tokens: 4096,
+      stream: true,
+    }),
+    parseResponse: (data) => ({
+      content: data.choices?.[0]?.message?.content || '',
+      tokens:
+        (data.usage?.prompt_tokens || 0) +
+        (data.usage?.completion_tokens || 0),
+    }),
+    parseStreamChunk: (line) => {
+      if (line === 'data: [DONE]') return { content: '', done: true }
+      if (!line.startsWith('data: ')) return null
+      try {
+        const json = JSON.parse(line.slice(6))
+        const delta = json.choices?.[0]?.delta?.content || ''
+        const finished = json.choices?.[0]?.finish_reason === 'stop'
+        return { content: delta, done: finished }
+      } catch {
+        return null
+      }
+    },
+  },
 }
 
 const ERROR_MESSAGES = {
@@ -175,7 +220,7 @@ async function handleErrorResponse(response) {
  * Run an agent against the specified LLM provider (one-shot, non-streaming).
  *
  * @param {Object} params
- * @param {'openai'|'anthropic'|'gemini'} params.provider
+ * @param {'openai'|'anthropic'|'gemini'|'openrouter'} params.provider
  * @param {string} params.model
  * @param {string} params.apiKey
  * @param {string} params.systemPrompt
@@ -238,7 +283,7 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
  * as it arrives so the UI can render progressively.
  *
  * @param {Object} params
- * @param {'openai'|'anthropic'|'gemini'} params.provider
+ * @param {'openai'|'anthropic'|'gemini'|'openrouter'} params.provider
  * @param {string} params.model
  * @param {string} params.apiKey
  * @param {string} params.systemPrompt

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://placeholder.supabase.co'
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'placeholder'
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary

- Added `openrouter` as a new provider in `PROVIDER_CONFIGS` within `src/lib/llmAdapter.js`
- OpenRouter uses the standard OpenAI-compatible chat completions endpoint at `https://openrouter.ai/api/v1/chat/completions`
- Includes SSE streaming support with chunk parsing (mirrors OpenAI's streaming format)
- Adds required headers: `Authorization: Bearer`, `HTTP-Referer`, and `X-Title`

## Implementation Details

- **No new dependencies** — fully leverages existing fetch-based architecture
- **Follows existing provider patterns** — `buildHeaders`, `buildBody`, `buildStreamBody`, `parseResponse`, and `parseStreamChunk` all implemented consistently with OpenAI/Anthropic/Gemini
- **Drop-in support** — agents can now specify `provider: 'openrouter'` with any OpenRouter API key

## Testing

- OpenRouter streaming verified working with multiple models
- Existing OpenAI, Anthropic, and Gemini providers unaffected

Fixes #147 
