### PR TITLE
Feat: add export workflow markdown button for completed workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 # OS
 .DS_Store
 Thumbs.db
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ dist-ssr
 # OS
 .DS_Store
 Thumbs.db
-.env

--- a/src/lib/exportMarkdown.js
+++ b/src/lib/exportMarkdown.js
@@ -1,0 +1,27 @@
+export function exportWorkflowAsMarkdown(workflowTitle, steps) {
+  const date = new Date().toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+
+  const filename = workflowTitle
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '') + '-output.md'
+
+  const stepContent = steps
+    .filter((s) => s.status === 'done' && s.output)
+    .map((s, i) => `## Step ${i + 1} — ${s.agentName}\n\n${s.output}`)
+    .join('\n\n---\n\n')
+
+  const content = `# ${workflowTitle} — Workflow Output\nGenerated on ${date}\n\n${stepContent}`
+
+  const blob = new Blob([content], { type: 'text/markdown' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -20,6 +20,7 @@ import ApiKeyBar from '../components/ApiKeyBar'
 import { useApiKey } from '../lib/useApiKey'
 import { runAgent } from '../lib/llmAdapter'
 import { fetchWorkflowById, incrementUsage } from '../hooks/useWorkflows'
+import { exportWorkflowAsMarkdown } from '../lib/exportMarkdown'
 
 const MODEL_MAP = {
   openai: 'gpt-4o',
@@ -330,7 +331,19 @@ export default function WorkflowRunner() {
           </button>
         )}
 
-        {allDone && <CopyAllButton steps={steps} />}
+        {allDone && (
+           <>
+            <CopyAllButton steps={steps} />
+            <button
+              onClick={() => exportWorkflowAsMarkdown(workflow?.title ?? 'workflow', steps)}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-colors
+               dark:bg-surface-card dark:border-border dark:text-text-secondary dark:hover:text-text-primary
+                bg-white border border-gray-200 text-gray-600 hover:text-gray-900"
+            >
+              Export as Markdown
+            </button>
+          </>
+        )}
       </div>
 
       {/* Steps */}


### PR DESCRIPTION
📄 Description
Adds an Export as Markdown button that appears after a workflow completes successfully, allowing users to download all step outputs as a single formatted .md file.
✅ Changes Made

Created src/lib/exportMarkdown.js — utility function using browser native download API, zero new dependencies
Added Export as Markdown button in src/pages/WorkflowRunner.jsx alongside existing Copy All Outputs button
File named after workflow title (e.g. hiring-pipeline-output.md)
Includes workflow title, generation date and all step outputs

🔗 Related Issue
Closes #93

<img width="1456" height="826" alt="export_as_markdown" src="https://github.com/user-attachments/assets/1771d01b-3636-4470-8b95-b86ef31dcb3d" />
<img width="1316" height="903" alt="md_file_opened" src="https://github.com/user-attachments/assets/0dcb2d3d-2f04-43cb-8a62-589c2b2be9fe" />


🎯 Program
GSSoC '26