### PR TITLE
feat: add suggested chain pills to agent pages(fixes #89)

### DIFF
--- a/src/agents/definitions/api-doc-generator.js
+++ b/src/agents/definitions/api-doc-generator.js
@@ -104,4 +104,5 @@ Rules:
 - Keep descriptions concise — one sentence per parameter
 - Never skip parameters or return values`,
   outputType: "markdown",
+  suggestedChainFrom: ["code-reviewer", "env-doc-generator"],
 };

--- a/src/agents/definitions/blog-post-seo-optimizer.js
+++ b/src/agents/definitions/blog-post-seo-optimizer.js
@@ -132,4 +132,5 @@ Rules:
 - Internal linking suggestions should be specific and actionable.
 - If the optimization focus is not "Full optimization", only produce the requested sections.`,
   outputType: "markdown",
+  suggestedChainFrom: ["research-agent", "pdf-summarizer"],
 };

--- a/src/agents/definitions/changelog-generator.js
+++ b/src/agents/definitions/changelog-generator.js
@@ -96,4 +96,5 @@ Rules:
 - If audience is "End users", avoid technical jargon
 - If audience is "Developers", include technical details`,
   outputType: "markdown",
+  suggestedChainFrom: ["code-reviewer", "bug-report-generator"],
 };

--- a/src/agents/definitions/cold-email-writer.js
+++ b/src/agents/definitions/cold-email-writer.js
@@ -58,4 +58,5 @@ export default {
   ],
   systemPrompt: `You are an expert B2B copywriter. Write a cold email that is highly personalised, addresses the pain point directly, and has a clear CTA. Do not use clichés. Output only the email — no explanation or commentary.`,
   outputType: "text",
+  suggestedChainFrom: ["research-agent", "competitive-analysis-generator"],
 };

--- a/src/agents/definitions/cover-letter-writer.js
+++ b/src/agents/definitions/cover-letter-writer.js
@@ -88,4 +88,5 @@ Rules:
   what makes the company compelling
 - Tone default: confident and direct`,
   outputType: "markdown",
+  suggestedChainFrom: ["resume-screener"],
 };

--- a/src/agents/definitions/incident-postmortem-writer.js
+++ b/src/agents/definitions/incident-postmortem-writer.js
@@ -116,4 +116,5 @@ Rules:
   but "add alert for query execution time > 5s on orders table"
 - Timeline must be chronological and in table format`,
   outputType: "markdown",
+  suggestedChainFrom: ["incident-runbook-generator"],
 };

--- a/src/agents/definitions/linkedin-post-writer.js
+++ b/src/agents/definitions/linkedin-post-writer.js
@@ -48,4 +48,5 @@ Requirements:
 Return ONLY the LinkedIn post ready to copy and publish.`,
 
   outputType: "markdown",
+  suggestedChainFrom: ["research-agent", "meeting-notes-summarizer"],
 };

--- a/src/agents/definitions/seo-keyword-planner.js
+++ b/src/agents/definitions/seo-keyword-planner.js
@@ -51,6 +51,7 @@ Follow these strict guidelines:
 After the table, provide a brief, 3-point action plan on how to execute this strategy based on their specific primary goal.
 Keep your response strictly focused, professional, and well-formatted.`,
   outputType: 'markdown',
+  suggestedChainFrom: ['research-agent', 'competitive-analysis-generator'],
 };
 
 export default seoKeywordStrategyPlanner;

--- a/src/agents/definitions/social-media-thread-writer.js
+++ b/src/agents/definitions/social-media-thread-writer.js
@@ -104,4 +104,5 @@ Rules:
 - No hashtag spam — 1-2 hashtags max, only on the last tweet
 - Format contrarian takes as: "Unpopular opinion:" or "Hot take:"`,
   outputType: "markdown",
+  suggestedChainFrom: ["research-agent", "meeting-notes-summarizer"],
 };

--- a/src/agents/definitions/unit-test-generator.js
+++ b/src/agents/definitions/unit-test-generator.js
@@ -74,4 +74,5 @@ Rules:
 - If the code has external dependencies (db, API, fs), add a note
   about what needs to be mocked and provide a basic mock setup`,
   outputType: "markdown",
+  suggestedChainFrom: ["code-reviewer", "code-complexity-analyzer"],
 };

--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -15,6 +15,7 @@ import ApiKeyBar from "./ApiKeyBar";
 import OutputRenderer from "./OutputRenderer";
 import ErrorCard from "./ErrorCard";
 import VoiceInput from "./VoiceInput";
+import SuggestedChainPills from "./SuggestedChainPills";
 import { useApiKey } from "../lib/useApiKey";
 import { streamAgent } from "../lib/llmAdapter";
 import { useHistory } from "../lib/useHistory";
@@ -421,6 +422,9 @@ export default function AgentRunner({ agent }) {
           </div>
         ))}
       </div>
+
+      {/* Suggested workflow chain pills */}
+      <SuggestedChainPills agent={agent} />
 
       <div className="mb-4">
         <button

--- a/src/components/SuggestedChainPills.jsx
+++ b/src/components/SuggestedChainPills.jsx
@@ -1,0 +1,69 @@
+import { useNavigate } from 'react-router-dom'
+import { GitBranch } from 'lucide-react'
+import * as Icons from 'lucide-react'
+import agents from '../agents/registry'
+
+/**
+ * Renders "Works well after" clickable pills for agents that define
+ * a `suggestedChainFrom` array in their definition.
+ *
+ * Clicking a pill navigates to /workflows/build with the pair
+ * pre-selected via React Router state.
+ */
+export default function SuggestedChainPills({ agent }) {
+  const navigate = useNavigate()
+
+  if (!agent.suggestedChainFrom?.length) return null
+
+  const predecessors = agent.suggestedChainFrom
+    .map((id) => agents.find((a) => a.id === id))
+    .filter(Boolean)
+
+  if (!predecessors.length) return null
+
+  const handlePillClick = (predecessor) => {
+    navigate('/workflows/build', {
+      state: {
+        preselectedAgents: [predecessor.id, agent.id],
+      },
+    })
+  }
+
+  return (
+    <div
+      className="mb-4 p-3 rounded-lg border
+        dark:bg-surface-card dark:border-border bg-white border-gray-200"
+    >
+      <div className="flex items-center gap-1.5 mb-2">
+        <GitBranch size={12} className="text-accent" />
+        <span
+          className="text-[11px] font-semibold uppercase tracking-wider
+            dark:text-text-muted text-gray-400"
+        >
+          Works well after
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {predecessors.map((pred) => {
+          const IconComponent = Icons[pred.icon] || Icons.Bot
+          return (
+            <button
+              key={pred.id}
+              onClick={() => handlePillClick(pred)}
+              title={`Start a workflow: ${pred.name} → ${agent.name}`}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium
+                border transition-all duration-150 active:scale-[0.97]
+                dark:bg-surface-input dark:border-border dark:text-text-secondary
+                dark:hover:border-accent/50 dark:hover:text-accent
+                bg-gray-50 border-gray-200 text-gray-600
+                hover:border-indigo-300 hover:text-indigo-600 hover:bg-indigo-50"
+            >
+              <IconComponent size={11} />
+              {pred.name}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/WorkflowBuilder.jsx
+++ b/src/pages/WorkflowBuilder.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import {
   ArrowLeft,
   Plus,
@@ -19,10 +19,17 @@ const MAX_AGENTS = 5
 
 export default function WorkflowBuilder() {
   const navigate = useNavigate()
+  const location = useLocation()
+
+  // Pre-populate chain when navigating from a SuggestedChainPills click
+  const preselected = location.state?.preselectedAgents ?? []
+  const initialAgents = preselected
+    .map((id) => agents.find((a) => a.id === id))
+    .filter(Boolean)
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
-  const [selectedAgents, setSelectedAgents] = useState([])
+  const [selectedAgents, setSelectedAgents] = useState(initialAgents)
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)


### PR DESCRIPTION
## What does this PR do?

fixes #89 

Adds "Works well after" suggested chain pills to agent pages. When a user lands on an agent like LinkedIn Post Writer, they now see clickable pills showing which agents pair well before it (e.g. Research Agent, Meeting Notes Summarizer). Clicking a pill opens Workflow Builder with that pair already loaded in the chain — no manual setup needed.

## Type of change

 - UI improvement


## Checklist
 
-  I was assigned to this issue before starting
-  I have read CONTRIBUTING.md
-  This PR is linked to issue #(your issue number)
-  I tested this locally with npm run dev
-  No API keys are anywhere in my code
-  I did not add any new packages without discussing it first