### PR TITLE
feat: add 'Send to Workflow' button on agent pages

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import * as Icons from "lucide-react";
 import {
   Loader2,
@@ -10,6 +11,7 @@ import {
   ChevronRight,
   Sparkles,
   RotateCw,
+  GitBranch,
 } from "lucide-react";
 import ApiKeyBar from "./ApiKeyBar";
 import OutputRenderer from "./OutputRenderer";
@@ -50,6 +52,7 @@ export default function AgentRunner({ agent }) {
   } = useApiKey();
 
   const { saveRun } = useHistory();
+  const navigate = useNavigate();
 
   const [inputs, setInputs] = useState({});
   const [output, setOutput] = useState(null);
@@ -255,6 +258,15 @@ export default function AgentRunner({ agent }) {
   const handleFillExample = () => {
     if (!agent.exampleInputs) return;
     setInputs((prev) => ({ ...prev, ...agent.exampleInputs }));
+  };
+
+  const handleSendToWorkflow = () => {
+    navigate("/workflows/build", {
+      state: {
+        preSelectedAgent: agent,
+        preFilledOutput: output,
+      },
+    });
   };
 
   const IconComponent = Icons[agent.icon] || Icons.Bot;
@@ -609,12 +621,24 @@ export default function AgentRunner({ agent }) {
       )}
 
       {output && !isStreaming && (
-        <OutputRenderer
-          content={output}
-          outputType={agent.outputType}
-          agentName={agent.name}
-          systemPrompt={customPrompt}
-        />
+        <div className="space-y-4">
+          <OutputRenderer
+            content={output}
+            outputType={agent.outputType}
+            agentName={agent.name}
+            systemPrompt={customPrompt}
+          />
+          <div className="flex justify-end">
+            <button
+              onClick={handleSendToWorkflow}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold
+                text-accent bg-accent/10 hover:bg-accent/20 transition-all border border-accent/20"
+            >
+              <GitBranch size={16} />
+              Send output to Workflow Builder →
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/pages/WorkflowBuilder.jsx
+++ b/src/pages/WorkflowBuilder.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import {
   ArrowLeft,
   Plus,
@@ -19,6 +19,7 @@ const MAX_AGENTS = 5
 
 export default function WorkflowBuilder() {
   const navigate = useNavigate()
+  const location = useLocation()
 
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -26,6 +27,18 @@ export default function WorkflowBuilder() {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
+
+  // Pre-select agent if coming from AgentRunner
+  useEffect(() => {
+    if (location.state?.preSelectedAgent) {
+      const agent = location.state.preSelectedAgent
+      setSelectedAgents([agent])
+      setTitle(`${agent.name} Workflow`)
+      
+      // Clear location state to prevent re-adding on refresh
+      window.history.replaceState({}, document.title)
+    }
+  }, [location.state])
 
   // Agents already in the chain — prevent duplicates
   const selectedIds = new Set(selectedAgents.map((a) => a.id))
@@ -70,6 +83,7 @@ export default function WorkflowBuilder() {
           description: description.trim(),
           agents: selectedAgents.map((a) => a.id),
         },
+        initialInput: location.state?.preFilledOutput || '',
       },
     })
   }

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -84,7 +84,7 @@ export default function WorkflowRunner() {
   const [loadingWorkflow, setLoadingWorkflow] = useState(!location.state?.workflow)
   const [fetchError, setFetchError] = useState(null)
 
-  const [userInput, setUserInput] = useState('')
+  const [userInput, setUserInput] = useState(location.state?.initialInput ?? '')
   const [running, setRunning] = useState(false)
   const [steps, setSteps] = useState([])
   const [allDone, setAllDone] = useState(false)


### PR DESCRIPTION
## What does this PR do?

This PR adds a "Send output to Workflow Builder" button that appears after an agent finishes its run. It allows users to instantly turn a single agent output into the starting point of a multi-agent workflow by pre-selecting the agent and pre-filling the output in the Workflow Builder.

## Type of change

- [.] Something else : Integration between Agent pages and Workflow Builder.

## Checklist

**For every PR:**
- [.] I was assigned to this issue before starting
- [.] I have read CONTRIBUTING.md
- [.] This PR is linked to issue #13 
- [.] I tested this locally with `npm run dev`
- [.] No API keys are anywhere in my code
- [.] I did not add any new packages without discussing it first



**Before:**

<img width="1253" height="797" alt="image" src="https://github.com/user-attachments/assets/3bfd169f-972b-40ac-917a-2ed0d49ea979" />



**After:**

<img width="1111" height="502" alt="Screenshot 2026-05-19 202913" src="https://github.com/user-attachments/assets/005abb0f-ed55-476d-b308-259475323ec1" />
<img width="918" height="742" alt="image" src="https://github.com/user-attachments/assets/2f52d610-0236-4782-be7e-e46ed6d54dd3" />





I updated three files:

[AgentRunner.jsx](vscode-file://vscode-app/c:/Users/asikk/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added the button and navigation logic using react-router-dom state.
[WorkflowBuilder.jsx](vscode-file://vscode-app/c:/Users/asikk/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added an effect to listen for the [preSelectedAgent](vscode-file://vscode-app/c:/Users/asikk/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) state.
[WorkflowRunner.jsx](vscode-file://vscode-app/c:/Users/asikk/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Updated to accept [initialInput](vscode-file://vscode-app/c:/Users/asikk/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from the builder state so the workflow actually starts with the pre-filled output.
