### PR TITLE
fix: add timeout handling for provider API requests

### DIFF
--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -394,8 +394,9 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
     let buffer = ''
+    let streamComplete = false
 
-    while (true) {
+    while (!streamComplete) {
       const { done, value } = await reader.read()
       if (done) break
 
@@ -418,7 +419,11 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
           onChunk(parsed.content)
         }
 
-        if (parsed.done) break
+        if (parsed.done) {
+          streamComplete = true
+          await reader.cancel()
+          break
+        }
       }
     }
 

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -195,6 +195,8 @@ const ERROR_MESSAGES = {
   503: 'The API service is temporarily unavailable. Try again in a minute.',
 }
 
+const DEFAULT_REQUEST_TIMEOUT = 60000 // 60 seconds
+
 /**
  * Handle non-OK HTTP responses consistently.
  */
@@ -214,6 +216,25 @@ async function handleErrorResponse(response) {
   throw new Error(
     detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
   )
+}
+
+/**
+ * Creates an AbortController with automatic timeout cleanup support.
+ */
+
+// TODO: wire up to runAgent and streamAgent
+
+function createTimeoutController(timeoutMs = DEFAULT_REQUEST_TIMEOUT) {
+  const controller = new AbortController()
+
+  const timeoutId = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
+
+  return {
+    controller,
+    cleanup: () => clearTimeout(timeoutId),
+  }
 }
 
 /**

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -195,7 +195,7 @@ const ERROR_MESSAGES = {
   503: 'The API service is temporarily unavailable. Try again in a minute.',
 }
 
-const DEFAULT_REQUEST_TIMEOUT = 60000 // 60 seconds
+const DEFAULT_REQUEST_TIMEOUT = 60000 // 60 seconds — override via timeoutMs param
 
 /**
  * Handle non-OK HTTP responses consistently.
@@ -219,10 +219,37 @@ async function handleErrorResponse(response) {
 }
 
 /**
- * Creates an AbortController with automatic timeout cleanup support.
+ * Merges multiple AbortSignals into one.
+ * Uses native AbortSignal.any when available, falls back to manual listeners.
+ *
+ * @param {AbortSignal[]} signals
+ * @returns {AbortSignal}
  */
+function combineSignals(signals) {
+  if (AbortSignal.any) {
+    return AbortSignal.any(signals)
+  }
 
-// TODO: wire up to runAgent and streamAgent
+  // Manual fallback for older browsers
+  const controller = new AbortController()
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort()
+      break
+    }
+    signal.addEventListener('abort', () => controller.abort(), { once: true })
+  }
+
+  return controller.signal
+}
+/**
+ * Creates an AbortController that automatically aborts
+ * requests after the configured timeout duration.
+ * Callers must invoke cleanup() to clear the timer when done.
+ *
+ * @param {number} [timeoutMs] — timeout in ms (default: 60000)
+ */
 
 function createTimeoutController(timeoutMs = DEFAULT_REQUEST_TIMEOUT) {
   const controller = new AbortController()
@@ -246,9 +273,10 @@ function createTimeoutController(timeoutMs = DEFAULT_REQUEST_TIMEOUT) {
  * @param {string} params.apiKey
  * @param {string} params.systemPrompt
  * @param {string} params.userMessage
+ * @param {number} [params.timeoutMs] — request timeout in ms (default: 60000)
  * @returns {Promise<{content: string, tokens: number, duration: number}>}
  */
-export async function runAgent({ provider, model, apiKey, systemPrompt, userMessage }) {
+export async function runAgent({ provider, model, apiKey, systemPrompt, userMessage, timeoutMs  }) {
   const config = PROVIDER_CONFIGS[provider]
 
   if (!config) {
@@ -268,12 +296,14 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
   const body = config.buildBody(model, systemPrompt, userMessage)
 
   const startTime = performance.now()
+  const {controller, cleanup} = createTimeoutController(timeoutMs)
 
   try {
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
+      signal: controller.signal,
     })
 
     if (!response.ok) {
@@ -290,12 +320,17 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
       duration,
     }
   } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error('Request timed out. The provider took too long to respond.')
+    }
     if (error.name === 'TypeError' && error.message === 'Failed to fetch') {
       throw new Error(
         "Couldn't reach the API. Check your internet connection and try again."
       )
     }
     throw error
+  } finally{
+    cleanup()
   }
 }
 
@@ -311,9 +346,10 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
  * @param {string} params.userMessage
  * @param {(text: string) => void} params.onChunk — called with each token/chunk
  * @param {AbortSignal} [params.signal] — optional AbortSignal to cancel streaming
+ * @param {number} [params.timeoutMs] — request timeout in ms (default: 60000)
  * @returns {Promise<{content: string, duration: number}>}
  */
-export async function streamAgent({ provider, model, apiKey, systemPrompt, userMessage, onChunk, signal }) {
+export async function streamAgent({ provider, model, apiKey, systemPrompt, userMessage, onChunk, signal, timeoutMs  }) {
   const config = PROVIDER_CONFIGS[provider]
 
   if (!config) {
@@ -338,12 +374,17 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
   const startTime = performance.now()
   let fullContent = ''
 
+  const {controller, cleanup} = createTimeoutController(timeoutMs )
+  const combinedSignal = signal
+    ? combineSignals([signal, controller.signal])
+    : controller.signal
+
   try {
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
-      signal,
+      signal: combinedSignal,
     })
 
     if (!response.ok) {
@@ -399,6 +440,9 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
   } catch (error) {
     if (error.name === 'AbortError') {
       const duration = Math.round(performance.now() - startTime)
+      if (controller.signal.aborted) {
+        throw new Error('Request timed out. The provider took too long to respond.')
+      }
       return { content: fullContent, duration }
     }
     if (error.name === 'TypeError' && error.message === 'Failed to fetch') {
@@ -407,5 +451,7 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
       )
     }
     throw error
+  } finally{
+    cleanup()
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds centralized timeout handling for provider API requests in `llmAdapter.js` to prevent requests from hanging indefinitely during provider-side issues, stalled streaming responses, or network interruptions.

Closes #204

### Changes

* Added a reusable timeout controller utility using `AbortController`
* Added automatic timeout handling for `runAgent`
* Added automatic timeout handling for `streamAgent`
* Added support for combining timeout and user cancellation signals
* Added a fallback implementation for environments that do not support `AbortSignal.any`
* Added consistent timeout error handling and cleanup logic

## Type of change

* [ ] New agent
* [x] Bug fix
* [ ] UI improvement
* [ ] Docs update
* [x] Something else (Reliability/Performance improvement)

## Checklist

**For every PR:**

* [x] I was assigned to this issue before starting
* [x] I have read CONTRIBUTING.md
* [x] This PR is linked to issue #204
* [x] I tested this locally with `npm run dev`
* [x] No API keys are anywhere in my code
* [x] I did not add any new packages without discussing it first

## Testing

* Verified the application runs locally using `npm run dev`
* Verified production build succeeds using `npm run build`
* Confirmed existing request execution continues to work
* Confirmed streaming functionality continues to work
* Confirmed timeout handling integrates without build/runtime errors

## Screenshots

No UI changes in this PR.

## Anything else I should know?

This implementation introduces centralized timeout handling for both one-shot and streaming provider requests while preserving existing manual cancellation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-request timeout for both standard and streaming AI agent requests.
  * Streaming now respects caller cancellation while also honoring the configured timeout.
* **Bug Fixes**
  * Clearer timeout-specific error messages and reliable timeout cleanup.
  * Streaming returns partial content on user-initiated aborts while signaling timeout vs. manual cancel distinctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->