### PR TITLE
feat: add smooth theme transition animations

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -15,6 +15,7 @@ export default function Navbar({ sidebarOpen, setSidebarOpen }) {
   }, [])
 
   const toggleTheme = () => {
+    document.documentElement.classList.add('transitioning')
     const next = !darkMode
     setDarkMode(next)
     if (next) {
@@ -24,6 +25,9 @@ export default function Navbar({ sidebarOpen, setSidebarOpen }) {
       document.documentElement.classList.remove('dark')
       localStorage.setItem('ila_theme', 'light')
     }
+    setTimeout(() => {
+      document.documentElement.classList.remove('transitioning')
+    }, 300)
   }
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -78,28 +78,60 @@ html:not(.dark) ::-webkit-scrollbar-thumb {
 
 /* ===== Animations ===== */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes slideInLeft {
-  from { opacity: 0; transform: translateX(-12px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 @keyframes pulse-ring {
-  0% { transform: scale(0.95); opacity: 0.5; }
-  50% { transform: scale(1.05); opacity: 0.3; }
-  100% { transform: scale(0.95); opacity: 0.5; }
+  0% {
+    transform: scale(0.95);
+    opacity: 0.5;
+  }
+
+  50% {
+    transform: scale(1.05);
+    opacity: 0.3;
+  }
+
+  100% {
+    transform: scale(0.95);
+    opacity: 0.5;
+  }
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes shimmer {
-  0% { background-position: -200% 0; }
-  100% { background-position: 200% 0; }
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 .animate-fade-in {
@@ -116,8 +148,15 @@ html:not(.dark) ::-webkit-scrollbar-thumb {
 
 /* Streaming cursor */
 @keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
 }
 
 .animate-blink {
@@ -247,13 +286,27 @@ html:not(.dark) .light-text-secondary {
 
 /* ===== Battle Mode Animations ===== */
 @keyframes battleFadeIn {
-  from { opacity: 0; transform: translateY(16px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes battleStepIn {
-  from { opacity: 0; transform: translateX(-20px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 @keyframes cardLiftGlow {
@@ -282,9 +335,12 @@ html:not(.dark) .light-text-secondary {
 }
 
 @keyframes buttonPulse {
-  0%, 100% {
+
+  0%,
+  100% {
     box-shadow: 0 0 0 0 currentColor;
   }
+
   50% {
     box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.1);
   }
@@ -294,9 +350,11 @@ html:not(.dark) .light-text-secondary {
   0% {
     transform: scale(1);
   }
+
   50% {
     transform: scale(0.98);
   }
+
   100% {
     transform: scale(1);
   }
@@ -313,6 +371,7 @@ html:not(.dark) .light-text-secondary {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -337,89 +396,147 @@ html:not(.dark) .light-text-secondary {
 }
 
 @keyframes slideInFromLeft {
-  from { opacity: 0; transform: translateX(-40px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
+
 @keyframes slideInFromRight {
-  from { opacity: 0; transform: translateX(40px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
+
 @keyframes glowPulse {
-  0%, 100% { box-shadow: 0 0 15px rgba(234, 179, 8, 0.4); }
-  50% { box-shadow: 0 0 35px rgba(234, 179, 8, 0.8), 0 0 60px rgba(234, 179, 8, 0.3); }
+
+  0%,
+  100% {
+    box-shadow: 0 0 15px rgba(234, 179, 8, 0.4);
+  }
+
+  50% {
+    box-shadow: 0 0 35px rgba(234, 179, 8, 0.8), 0 0 60px rgba(234, 179, 8, 0.3);
+  }
 }
+
 .battle-slide-left {
   opacity: 0;
   animation: slideInFromLeft 0.6s ease-out forwards;
 }
+
 .battle-slide-right {
   opacity: 0;
   animation: slideInFromRight 0.6s ease-out forwards;
 }
+
 .battle-slide-center {
   opacity: 0;
   animation: battleFadeIn 0.6s ease-out forwards;
 }
+
 .battle-glow-pulse {
   animation: glowPulse 2s ease-in-out infinite;
 }
+
 .battle-glow-violet {
   box-shadow: 0 0 30px rgba(167, 139, 250, 0.15), 0 0 60px rgba(167, 139, 250, 0.05);
 }
+
 .battle-glow-blue {
   box-shadow: 0 0 30px rgba(96, 165, 250, 0.15), 0 0 60px rgba(96, 165, 250, 0.05);
 }
+
 .battle-card-yellow {
   border-color: rgb(250, 204, 21, 0.3);
   transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+
 .battle-card-yellow:hover {
   border-color: rgb(250, 204, 21, 0.6);
   box-shadow: 0 0 30px rgba(250, 204, 21, 0.25), 0 0 60px rgba(250, 204, 21, 0.1), 0 15px 35px rgba(250, 204, 21, 0.1);
   transform: translateY(-6px);
 }
+
 .battle-card-violet {
   border-color: rgb(167, 139, 250, 0.3);
   transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+
 .battle-card-violet:hover {
   border-color: rgb(167, 139, 250, 0.6);
   box-shadow: 0 0 30px rgba(167, 139, 250, 0.25), 0 0 60px rgba(167, 139, 250, 0.1), 0 15px 35px rgba(167, 139, 250, 0.1);
   transform: translateY(-6px);
 }
+
 .battle-card-blue {
   border-color: rgb(96, 165, 250, 0.3);
   transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
+
 .battle-card-blue:hover {
   border-color: rgb(96, 165, 250, 0.6);
   box-shadow: 0 0 30px rgba(96, 165, 250, 0.25), 0 0 60px rgba(96, 165, 250, 0.1), 0 15px 35px rgba(96, 165, 250, 0.1);
   transform: translateY(-6px);
 }
+
 .battle-btn-primary {
   transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
   position: relative;
 }
+
 .battle-btn-primary:hover {
   animation: buttonPulse 0.6s ease-out infinite;
 }
+
 .battle-btn-primary:active {
   animation: buttonPress 0.15s ease-out forwards;
 }
+
 .battle-btn-secondary {
   transition: all 0.2s ease-out;
   border-width: 2px;
 }
+
 .battle-btn-secondary:hover {
   background-color: rgba(255, 255, 255, 0.08);
   transform: translateY(-2px);
 }
+
 .battle-btn-secondary:active {
   transform: scale(0.97);
 }
+
 .battle-select-highlight {
   transition: all 0.2s ease-out;
 }
+
 .battle-select-highlight:focus {
   background-color: rgba(255, 255, 255, 0.03);
+}
+
+
+/* Smooth Theme Transition */
+
+html.transitioning *,
+html.transitioning *::before,
+html.transitioning *::after {
+  transition:
+    background-color 300ms ease,
+    color 300ms ease,
+    border-color 300ms ease,
+    fill 300ms ease,
+    stroke 300ms ease,
+    box-shadow 300ms ease !important;
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds smooth animation while changing the modes from light to dark or vice versa.

## Type of change

- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

Closes #134 

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #134 
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)


**Before:**

<img width="800" height="405" alt="ezgif-2c9fd0baf5edf524" src="https://github.com/user-attachments/assets/f8672d59-7c5d-4762-9d96-8a6de70beb97" />


**After:**

<img width="800" height="401" alt="ezgif-23be8fd83ca987ee" src="https://github.com/user-attachments/assets/ffd41753-79ac-4631-a897-9837507911a5" />


## Anything else I should know?

Commit message written using AI. 
