### PR TITLE
docs: move agents table to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# 🤖 Available Agents
+
+34 agents and growing — built by the community. 🚀
+
+| # | Agent | What It Does | Category |
+|---|-------|-------------|----------|
+| 1 | PDF Summarizer | Extracts structured summaries from PDF text with key points and action items | Productivity |
+| 2 | Research Agent | Comprehensive research on any topic with configurable depth and format | Research |
+| 3 | Cold Email Writer | Generates personalized B2B cold emails with tone and length control | Marketing |
+| 4 | Code Reviewer | Senior-level code review with issue detection, scoring, and fix suggestions | Engineering |
+| 5 | Resume Screener | Evaluates candidates against job descriptions with visual scorecard output | HR |
+| 6 | LinkedIn Post Writer | Creates ready-to-post LinkedIn content with strong hooks and hashtags | Marketing |
+| 7 | Meeting Notes Summarizer | Turns raw meeting notes into clean summaries with decisions and action items | Productivity |
+| 8 | SQL Query Generator | Converts plain English questions into optimized SQL with explanations | Engineering |
+| 9 | Regex Generator | Translates plain English descriptions into tested regex patterns with breakdowns | Engineering |
+| 10 | Startup Idea Validator | Analyzes startup ideas with market potential, competition, risks, and viability scoring | Business |
+| 11 | ELI5 Explainer | Explains complex topics in plain language at your chosen difficulty level | Education |
+| 12 | API Doc Generator | Paste code and get clean, professional API documentation with examples | Engineering |
+| 13 | Email Reply Writer | Paste any email and describe how you want to respond. Get a polished reply in seconds | Productivity |
+| 14 | Bug Report Generator | Describe a bug in plain English and get a complete structured bug report ready for GitHub or Jira | Engineering |
+| 15 | Performance Review Writer | Turn bullet notes about an employee into a structured, fair performance review | HR |
+| 16 | Cover Letter Writer | Paste a job description and your background. Get a tailored cover letter that actually sounds like you | HR |
+| 17 | Incident Post-Mortem Writer | Turn rough incident notes into a blameless post-mortem with timeline, root cause, and action items | Engineering |
+| 18 | Changelog Generator | Paste git commits or PR titles and get a clean user-facing changelog | Engineering |
+| 19 | Unit Test Generator | Paste any function and get complete unit tests with edge cases and failure scenarios | Engineering |
+| 20 | Flashcard Generator | Paste any study material and get ready-to-use flashcards in Q&A format for Anki or Quizlet | Education |
+| 21 | Invoice Description Generator | Turn rough work notes into polished invoice line items and a project summary | Productivity |
+| 22 | Grant Proposal Writer | Describe your project and get a structured grant proposal with problem statement and methodology | Education |
+| 23 | Social Media Thread Writer | Turn any topic into a compelling X/Twitter thread with hooks and a strong call to action | Marketing |
+| 24 | Privacy Policy Generator | Describe your app and get a comprehensive privacy policy draft | Legal |
+| 25 | Cron Expression Builder | Describe when you want a job to run and get the correct cron expression with explanation | Engineering |
+| 26 | Color Palette Generator | Describe a mood or brand and get a complete color palette with hex codes and CSS variables | Design |
+| 27 | User Story Writer | Describe a feature and get a well-structured user story with acceptance criteria and edge cases | Product |
+| 28 | Persona Generator | Describe your product and get detailed realistic user personas with goals and frustrations | Product |
+| 29 | Competitive Analysis Generator | Name your product and competitors and get a structured competitive analysis | Business |
+| 30 | Tone Rewriter | Paste any text and get it rewritten in your chosen tone — formal, casual, diplomatic, or concise | Productivity |
+| 31 | Data Dictionary Generator | Paste your schema and get a complete data dictionary with field definitions and relationships | Engineering |
+| 32 | Accessibility Audit Generator | Paste your HTML and get a detailed WCAG audit with issues, severity ratings, and fixes | Engineering |
+| 33 | Personal Budget Analyzer | Analyze monthly income and expenses to get savings rate, benchmarks, and financial recommendations | Finance |
+| 34 | K8s Manifest Generator | Generates a full Kubernetes manifest from your app name, container image, port, and optional config | DevOps |
+> Want to add your own? It takes about 5 minutes. See [Contributing](#contributing) below.

--- a/README.md
+++ b/README.md
@@ -39,45 +39,7 @@ Each agent is a focused tool that does one thing really well — summarize meeti
 
 ## Available Agents
 
-34 agents and growing — built by the community. 🚀
-
-| # | Agent | What It Does | Category |
-|---|-------|-------------|----------|
-| 1 | PDF Summarizer | Extracts structured summaries from PDF text with key points and action items | Productivity |
-| 2 | Research Agent | Comprehensive research on any topic with configurable depth and format | Research |
-| 3 | Cold Email Writer | Generates personalized B2B cold emails with tone and length control | Marketing |
-| 4 | Code Reviewer | Senior-level code review with issue detection, scoring, and fix suggestions | Engineering |
-| 5 | Resume Screener | Evaluates candidates against job descriptions with visual scorecard output | HR |
-| 6 | LinkedIn Post Writer | Creates ready-to-post LinkedIn content with strong hooks and hashtags | Marketing |
-| 7 | Meeting Notes Summarizer | Turns raw meeting notes into clean summaries with decisions and action items | Productivity |
-| 8 | SQL Query Generator | Converts plain English questions into optimized SQL with explanations | Engineering |
-| 9 | Regex Generator | Translates plain English descriptions into tested regex patterns with breakdowns | Engineering |
-| 10 | Startup Idea Validator | Analyzes startup ideas with market potential, competition, risks, and viability scoring | Business |
-| 11 | ELI5 Explainer | Explains complex topics in plain language at your chosen difficulty level | Education |
-| 12 | API Doc Generator | Paste code and get clean, professional API documentation with examples | Engineering |
-| 13 | Email Reply Writer | Paste any email and describe how you want to respond. Get a polished reply in seconds | Productivity |
-| 14 | Bug Report Generator | Describe a bug in plain English and get a complete structured bug report ready for GitHub or Jira | Engineering |
-| 15 | Performance Review Writer | Turn bullet notes about an employee into a structured, fair performance review | HR |
-| 16 | Cover Letter Writer | Paste a job description and your background. Get a tailored cover letter that actually sounds like you | HR |
-| 17 | Incident Post-Mortem Writer | Turn rough incident notes into a blameless post-mortem with timeline, root cause, and action items | Engineering |
-| 18 | Changelog Generator | Paste git commits or PR titles and get a clean user-facing changelog | Engineering |
-| 19 | Unit Test Generator | Paste any function and get complete unit tests with edge cases and failure scenarios | Engineering |
-| 20 | Flashcard Generator | Paste any study material and get ready-to-use flashcards in Q&A format for Anki or Quizlet | Education |
-| 21 | Invoice Description Generator | Turn rough work notes into polished invoice line items and a project summary | Productivity |
-| 22 | Grant Proposal Writer | Describe your project and get a structured grant proposal with problem statement and methodology | Education |
-| 23 | Social Media Thread Writer | Turn any topic into a compelling X/Twitter thread with hooks and a strong call to action | Marketing |
-| 24 | Privacy Policy Generator | Describe your app and get a comprehensive privacy policy draft | Legal |
-| 25 | Cron Expression Builder | Describe when you want a job to run and get the correct cron expression with explanation | Engineering |
-| 26 | Color Palette Generator | Describe a mood or brand and get a complete color palette with hex codes and CSS variables | Design |
-| 27 | User Story Writer | Describe a feature and get a well-structured user story with acceptance criteria and edge cases | Product |
-| 28 | Persona Generator | Describe your product and get detailed realistic user personas with goals and frustrations | Product |
-| 29 | Competitive Analysis Generator | Name your product and competitors and get a structured competitive analysis | Business |
-| 30 | Tone Rewriter | Paste any text and get it rewritten in your chosen tone — formal, casual, diplomatic, or concise | Productivity |
-| 31 | Data Dictionary Generator | Paste your schema and get a complete data dictionary with field definitions and relationships | Engineering |
-| 32 | Accessibility Audit Generator | Paste your HTML and get a detailed WCAG audit with issues, severity ratings, and fixes | Engineering |
-| 33 | Personal Budget Analyzer | Analyze monthly income and expenses to get savings rate, benchmarks, and financial recommendations | Finance |
-| 34 | K8s Manifest Generator | Generates a full Kubernetes manifest from your app name, container image, port, and optional config | DevOps |
-> Want to add your own? It takes about 5 minutes. See [Contributing](#contributing) below.
+The complete list of agents has been moved to [AGENTS.md](./AGENTS.md) for better organization and scalability.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

This PR improves repository organization by moving the growing Available Agents table from `README.md` to a dedicated `AGENTS.md` file for better scalability and readability.

## Type of change

* [ ] New agent
* [ ] Bug fix
* [ ] UI improvement
* [x] Docs update
* [ ] Something else (describe below)

## Checklist

**For every PR:**

* [x] I was assigned to this issue before starting
* [x] I have read CONTRIBUTING.md
* [x] This PR is linked to issue #1032
* [x] I tested this locally with `npm run dev`
* [x] No API keys are anywhere in my code
* [x] I did not add any new packages without discussing it first

**For new agent PRs:**

* [ ] I tested the agent with a real API key
* [ ] I created a new file in `src/agents/definitions/` with the agent config
* [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
* [ ] The icon name is from [[lucide.dev/icons](https://lucide.dev/icons)](https://lucide.dev/icons)
* [ ] The system prompt clearly describes the format of the output
* [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

Not applicable — this PR only reorganizes documentation files.

## Anything else I should know?

The PR is intentionally kept minimal and focused only on moving the Available Agents section into `AGENTS.md`, as requested in the issue discussion.
