### PR TITLE
feat: add PR Diff Reviewer agent

### DIFF
--- a/src/agents/categories.js
+++ b/src/agents/categories.js
@@ -13,6 +13,7 @@ export const CATEGORIES = [
   "Cybersecurity",
   "Data Science",
   "Design",
+  "Developer Tools",
   "Education",
   "Engineering",
   "Finance",

--- a/src/agents/definitions/pr-diff-reviewer.js
+++ b/src/agents/definitions/pr-diff-reviewer.js
@@ -1,0 +1,120 @@
+export default {
+  id: "pr-diff-reviewer",
+  createdAt: "2026-05-21",
+  name: "PR Diff Reviewer",
+  description:
+    "Review a raw git/PR diff and get structured feedback on the changed lines only.",
+  category: "Developer Tools",
+  icon: "GitPullRequest",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-opus-4-20250514",
+  exampleInputs: {
+    diff: `diff --git a/src/api/users.js b/src/api/users.js
+index 8c1a2b3..d4e5f6a 100644
+--- a/src/api/users.js
++++ b/src/api/users.js
+@@ -1,8 +1,12 @@
+ import fetch from 'node-fetch'
+
+-const API_BASE = process.env.API_BASE
++const API_BASE = 'https://api.example.com'
++const API_KEY = 'sk_live_9f8a7b6c5d4e3f2a1b0c'
+
+ export async function getUser(id) {
+-  const res = await fetch(\`\${API_BASE}/users/\${id}\`)
+-  return res.json()
++  const res = await fetch(\`\${API_BASE}/users/\${id}\`, {
++    headers: { Authorization: \`Bearer \${API_KEY}\` },
++  })
++  const data = await res.json()
++  return data.user.name
+ }`,
+    focus: ["Bugs & Regressions", "Security", "Error Handling & Edge Cases"],
+  },
+  inputs: [
+    {
+      id: "diff",
+      label: "Git / PR Diff",
+      type: "code",
+      placeholder:
+        "Paste a unified diff here (output of `git diff`, or a PR .diff file)...",
+      required: true,
+    },
+    {
+      id: "focus",
+      label: "Review focus",
+      type: "multiselect",
+      options: [
+        "Bugs & Regressions",
+        "Security",
+        "Readability & Naming",
+        "Error Handling & Edge Cases",
+        "Performance",
+      ],
+      defaultValue: [
+        "Bugs & Regressions",
+        "Security",
+        "Error Handling & Edge Cases",
+      ],
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a senior software engineer performing a focused pull-request review.
+Your input is a raw git/unified diff. Review ONLY the changes in the diff — never
+comment on code that is unchanged.
+
+How to read the diff:
+- Lines starting with "diff --git", "index", "---", "+++" are file headers — they
+  tell you which files changed.
+- "@@ -old,count +new,count @@" marks a hunk and gives the new-file line numbers.
+- Lines starting with "+" are ADDED. Lines starting with "-" are REMOVED. Lines
+  starting with a space are unchanged CONTEXT — use them only to understand the
+  surroundings, never review them.
+- Cite every issue with the file path and the new-file line number derived from the
+  nearest "@@" hunk header.
+
+If the diff is very large, prioritize the hunks with the highest regression risk
+(logic changes, auth, data handling, error paths) and explicitly state which files
+you deprioritized.
+
+Focus your review on the areas the user selected. Always consider: bugs and
+regressions the change could introduce, readability and naming of the changed
+lines, missing error handling and edge cases, and security (hardcoded secrets,
+injection, unsafe eval/exec, exposed data).
+
+Output clean GitHub-flavored markdown using EXACTLY these sections and headings:
+
+## Summary
+2-4 sentences: what the diff changes and why, in plain language.
+
+## Issues Found
+One bullet per concrete problem introduced by the diff. Start each bullet with a
+severity tag and a location:
+- **[Critical|High|Medium|Low]** \`path/to/file:line\` — the problem and the
+  regression it could cause.
+If you find no issues, write: "No blocking issues found in the changed lines."
+
+## Suggestions
+Concise, actionable improvements for readability, naming, structure, or missing
+tests/edge cases in the changed lines. Use a bullet list. Include a short corrected
+code snippet only when it makes the fix clearer.
+
+## Security Notes
+Security concerns introduced by the diff: hardcoded secrets or keys, injection,
+unsafe eval/exec, missing validation, exposed sensitive data. If none, write:
+"No security concerns identified in this diff."
+
+## Risk Assessment
+- **Risk score: X/10** (1 = trivial and safe, 10 = high chance of breaking
+  production).
+- One sentence justifying the score based on the issues above.
+
+Rules:
+- Review only added/removed lines; never invent code that is not in the diff.
+- Be specific and concise — every bullet must be actionable.
+- Severity guide: Critical = data loss / security breach / guaranteed crash;
+  High = likely bug or regression; Medium = edge case or maintainability risk;
+  Low = style or naming.`,
+  outputType: "markdown",
+};

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -22,6 +22,7 @@ const categoryMeta = {
   Legal:        { color: 'from-red-500 to-rose-400',      ring: 'ring-red-500/30' },
   Design:       { color: 'from-fuchsia-500 to-pink-400',  ring: 'ring-fuchsia-500/30' },
   Product:      { color: 'from-teal-500 to-cyan-400',     ring: 'ring-teal-500/30' },
+  'Developer Tools': { color: 'from-slate-600 to-slate-400', ring: 'ring-slate-500/30' },
 }
 
 const defaultMeta = { color: 'from-gray-500 to-gray-400', ring: 'ring-gray-500/30' }


### PR DESCRIPTION
### Summary

Adds a **PR Diff Reviewer** agent that takes a raw git/unified diff and returns structured, change-focused feedback on the modified lines only.

### New agent

- **Location:** `src/agents/definitions/pr-diff-reviewer.js`
- **Category:** Developer Tools _(new category — added to `src/agents/categories.js`)_
- **Input:** raw git/unified diff (`git diff` output or a PR `.diff`) + a review-focus multiselect
- **Output:** markdown — **Summary**, **Issues Found** (severity-tagged), **Suggestions**, **Security Notes**, **Risk Assessment** (1–10 score)

### How it differs from the existing Code Reviewer (PR #4)

| | Code Reviewer (PR #4) | PR Diff Reviewer (this PR) |
|---|---|---|
| Input | Arbitrary code snippet + language | Raw git/unified diff |
| Scope | Whole submitted snippet | Only changed hunks (`+`/`-` lines) |
| Emphasis | General quality / best practices | Change impact & regression risk |
| Category | Engineering | Developer Tools |

It **complements** the snippet Code Reviewer rather than duplicating it — context lines are used only for context and never reviewed.

### Usage

Home → **Developer Tools** category → **PR Diff Reviewer**. Paste a unified diff, pick focus areas, and run. A bundled example diff is available via the **Try an example** button.

Example input:

```diff
diff --git a/src/api/users.js b/src/api/users.js
@@ -1,8 +1,12 @@
-const API_BASE = process.env.API_BASE
+const API_BASE = 'https://api.example.com'
+const API_KEY = 'sk_live_9f8a7b6c5d4e3f2a1b0c'
```

Expected behaviour: the agent flags the hardcoded `API_KEY` under **Security Notes**, flags the unguarded `data.user.name` access under **Issues Found** with a severity tag, and assigns an overall risk score.

### Testing

- `npm run build` passes — all modules transformed with no errors; the agent is auto-discovered by the registry.
- `npm run dev` boots clean.
- **Runtime LLM testing pending:** the agent still needs to be exercised against a live provider API key. Suggested manual checks before merge:
  - A diff introducing an off-by-one bug (e.g. `<=` → `<` on a loop bound) → expect a severity-tagged entry under **Issues Found**.
  - A diff adding a hardcoded secret (`const KEY = "sk_live_..."`) → expect it flagged under **Security Notes**.
  - A pure rename/refactor diff → expect only low-severity readability notes.
  - In each case, confirm feedback is scoped strictly to changed (`+`/`-`) lines and renders cleanly as markdown.

### Notes

- No new dependencies. Reuses the existing LLM adapter, `code` input type (monospace diff textarea), and the markdown renderer.
- The registry auto-discovers the new agent file — no change to `registry.js`.
- Per maintainer guidance, issue #196's title should be updated to **"Add agent: PR Diff Reviewer"**.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
