### PR TITLE
Fix/provider key fallback ux

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -207,11 +207,16 @@ export default function AgentRunner({ agent }) {
         output: result.content,
         provider: actualProvider,
       });
-    } catch (err) {
-      if (err.name !== "AbortError") {
-        setError(err.message);
-      }
-    } finally {
+   } catch (err) {
+  if (err.name !== "AbortError") {
+    // If the error is our structured invalid-api-key error, pass it directly
+    if (err && err.type === "invalid_api_key") {
+      setError(err);
+    } else {
+      setError({ type: "generic", message: err.message });
+    }
+  }
+} finally {
       setLoading(false);
       abortControllerRef.current = null;
     }
@@ -567,7 +572,41 @@ export default function AgentRunner({ agent }) {
         )}
       </div>
 
-      {error && <ErrorCard message={error} />}
+      {error && error.type === "invalid_api_key" ? (
+  <ErrorCard message={
+    <>
+      <strong>
+        {error.provider === "openai" && "Your OpenAI API key is invalid or expired."}
+        {error.provider === "anthropic" && "Your Anthropic API key is invalid or expired."}
+        {error.provider === "gemini" && "Your Google Gemini API key is invalid or expired."}
+        {!["openai", "anthropic", "gemini"].includes(error.provider) && "Your API key is invalid or expired."}
+      </strong>
+      <br />
+      Please check and update your API key.<br />
+      <button
+        className="underline text-accent"
+        onClick={() => window.dispatchEvent(new CustomEvent("open-api-key-bar"))}
+      >
+        Update API Key
+      </button>
+      <span> or </span>
+      <button
+        className="underline text-accent"
+        onClick={() => window.location.reload()}
+      >
+        Retry
+      </button>
+      {error.detail && (
+        <>
+          <br /><br />
+          <span className="text-xs text-gray-400">Details: {error.detail}</span>
+        </>
+      )}
+    </>
+  } />
+) : (
+  error && <ErrorCard message={error.message || error} />
+)}
 
       {loading && !isStreaming && (
         <div className="rounded-lg border p-6 dark:bg-surface-card dark:border-border bg-white border-gray-200 text-center animate-fade-in">

--- a/src/components/ErrorCard.jsx
+++ b/src/components/ErrorCard.jsx
@@ -32,9 +32,7 @@ export default function ErrorCard({ message }) {
           }`}>
             {color === 'error' ? 'Error' : 'Warning'}
           </h4>
-          <p className="text-xs dark:text-text-secondary text-gray-600 leading-relaxed whitespace-pre-wrap">
-            {message}
-          </p>
+          <p className="text-xs ...">{typeof message === "string" ? message : message}</p>
         </div>
       </div>
     </div>

--- a/src/components/ErrorCard.jsx
+++ b/src/components/ErrorCard.jsx
@@ -3,14 +3,18 @@ import { AlertTriangle, XCircle, Wifi } from 'lucide-react'
 export default function ErrorCard({ message }) {
   // Determine icon based on error content
   let Icon = XCircle
-  let color = 'error'
-  if (message.includes('Rate limit')) {
-    Icon = AlertTriangle
-    color = 'warning'
-  } else if (message.includes('connection') || message.includes('reach')) {
-    Icon = Wifi
-    color = 'warning'
-  }
+let color = 'error'
+
+// Only call .includes if message is a string!
+if (typeof message === 'string' && message.includes('Rate limit')) {
+  Icon = AlertTriangle
+  color = 'warning'
+} else if (
+  typeof message === 'string' && (message.includes('connection') || message.includes('reach'))
+) {
+  Icon = Wifi
+  color = 'warning'
+}
 
   return (
     <div className={`rounded-lg border p-4 animate-fade-in
@@ -32,7 +36,11 @@ export default function ErrorCard({ message }) {
           }`}>
             {color === 'error' ? 'Error' : 'Warning'}
           </h4>
-          <p className="text-xs ...">{typeof message === "string" ? message : message}</p>
+          {typeof message === "string" ?
+  <p className="text-xs dark:text-text-secondary text-gray-600 leading-relaxed whitespace-pre-wrap">{message}</p>
+  :
+  <div className="text-xs dark:text-text-secondary text-gray-600 leading-relaxed whitespace-pre-wrap">{message}</div>
+}
         </div>
       </div>
     </div>

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -169,6 +169,44 @@ async function handleErrorResponse(response) {
   throw new Error(
     detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
   )
+}const ERROR_MESSAGES = {
+  401: 'invalid_api_key', // We'll use a key to help downstream logic
+  403: 'Access forbidden. Your API key may not have the required permissions.',
+  429: 'Rate limit hit. Wait a moment and try again.',
+  500: 'The API server encountered an error. Try again shortly.',
+  502: 'Bad gateway — the API is temporarily unavailable.',
+  503: 'The API service is temporarily unavailable. Try again in a minute.',
+};
+
+/**
+ * Handle non-OK HTTP responses consistently.
+ */
+async function handleErrorResponse(response, provider = "unknown") {
+  const errorKey = ERROR_MESSAGES[response.status] || null;
+  let detail = '';
+  try {
+    const errBody = await response.json();
+    detail = errBody?.error?.message || JSON.stringify(errBody);
+  } catch {
+    // Could not parse error body
+  }
+
+  if (errorKey === 'invalid_api_key') {
+    throw {
+      type: "invalid_api_key",
+      provider,
+      detail: detail || 'No additional details',
+    };
+  }
+
+  const friendlyMessage =
+    typeof ERROR_MESSAGES[response.status] === 'string'
+      ? ERROR_MESSAGES[response.status]
+      : `API returned status ${response.status}. Please check your configuration.`;
+
+  throw new Error(
+    detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
+  );
 }
 
 /**
@@ -210,9 +248,9 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
       body: JSON.stringify(body),
     })
 
-    if (!response.ok) {
-      await handleErrorResponse(response)
-    }
+   if (!response.ok) {
+  await handleErrorResponse(response, provider)
+}
 
     const data = await response.json()
     const parsed = config.parseResponse(data)

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -219,9 +219,9 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
       body: JSON.stringify(body),
     })
 
-   if (!response.ok) {
-  await handleErrorResponse(response, provider)
-}
+    if (!response.ok) {
+      await handleErrorResponse(response, provider)
+    }
 
     const data = await response.json()
     const parsed = config.parseResponse(data)

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -142,34 +142,6 @@ const PROVIDER_CONFIGS = {
 }
 
 const ERROR_MESSAGES = {
-  401: 'Invalid API key. Please check your key and try again.',
-  403: 'Access forbidden. Your API key may not have the required permissions.',
-  429: 'Rate limit hit. Wait a moment and try again.',
-  500: 'The API server encountered an error. Try again shortly.',
-  502: 'Bad gateway — the API is temporarily unavailable.',
-  503: 'The API service is temporarily unavailable. Try again in a minute.',
-}
-
-/**
- * Handle non-OK HTTP responses consistently.
- */
-async function handleErrorResponse(response) {
-  const friendlyMessage =
-    ERROR_MESSAGES[response.status] ||
-    `API returned status ${response.status}. Please check your configuration.`
-
-  let detail = ''
-  try {
-    const errBody = await response.json()
-    detail = errBody?.error?.message || JSON.stringify(errBody)
-  } catch {
-    // Could not parse error body
-  }
-
-  throw new Error(
-    detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
-  )
-}const ERROR_MESSAGES = {
   401: 'invalid_api_key', // We'll use a key to help downstream logic
   403: 'Access forbidden. Your API key may not have the required permissions.',
   429: 'Rate limit hit. Wait a moment and try again.',
@@ -208,7 +180,6 @@ async function handleErrorResponse(response, provider = "unknown") {
     detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
   );
 }
-
 /**
  * Run an agent against the specified LLM provider (one-shot, non-streaming).
  *


### PR DESCRIPTION
## What does this PR do?

- Shows a clear, user-friendly error message when an invalid or expired provider API key (OpenAI, Anthropic, Gemini) is entered.
- Provides actionable options ("Update API Key", "Retry") on error.
- Prevents blank screens or crashes—users are now guided to recover.

## Background

Fixes #179

Previously, entering a bad API key could result in a generic error or broken experience. This PR ensures all provider auth errors are handled with straightforward UX, matching the project maintainers' recommendations.

## How to test

1. Go to any agent and open the "API Key" bar or settings.
2. Enter a deliberately invalid key (e.g., `INVALID_KEY_123`).
3. Trigger the agent—observe the error message and recovery actions.
4. Confirm no uncaught errors in the browser console.

## Notes

- Bug fix is robust for all supported providers.
- ErrorCard now gracefully handles both string and JSX/object error messages.

Tested locally—ready for review!