### PR TITLE
implemented dynamic gemini model fetching

### DIFF
--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { fetchGeminiModels } from '../lib/llmAdapter'
+import { useState, useEffect } from 'react'
 import { Eye, EyeOff, ShieldCheck } from 'lucide-react'
 import { MODELS } from '../lib/resolveAgentModel'
 import openaiLogo from "../assets/openai.svg";
@@ -31,6 +32,32 @@ export default function ApiKeyBar({
   setModel,
 }) {
   const [showKey, setShowKey] = useState(false)
+  const [geminiModels, setGeminiModels] = useState([])
+  const [geminiLoading, setGeminiLoading] = useState(false)
+  const [geminiError, setGeminiError] = useState(null)
+
+  useEffect(() => {
+    if (provider !== 'gemini' || !apiKey?.trim()) {
+      setGeminiModels([])
+      setGeminiError(null)
+      return
+    }
+    const timer = setTimeout(async () => {
+      setGeminiLoading(true)
+      setGeminiError(null)
+      try {
+        const models = await fetchGeminiModels(apiKey)
+        setGeminiModels(models)
+        if (models.length > 0) setModel(models[0].value)
+      } catch {
+        setGeminiError('Could not load Gemini models. Check your API key.')
+        setGeminiModels([])
+      } finally {
+        setGeminiLoading(false)
+      }
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [provider, apiKey])
 
   // Filter providers if agent requires a specific one
   const availableProviders =
@@ -38,7 +65,8 @@ export default function ApiKeyBar({
       ? PROVIDERS
       : PROVIDERS.filter((p) => p.value === agentProvider)
 
-  const availableModels = MODELS[provider] || []
+  const availableModels =
+    provider === 'gemini' ? geminiModels : MODELS[provider] || []
 
   return (
     <div className="rounded-lg border p-3 mb-4 transition-theme
@@ -76,16 +104,21 @@ export default function ApiKeyBar({
         <select
           value={model}
           onChange={(e) => setModel(e.target.value)}
+          disabled={geminiLoading}
           className="h-8 px-2.5 rounded-md text-xs font-medium transition-colors cursor-pointer
             dark:bg-surface-input dark:border-border dark:text-text-primary
             bg-gray-50 border border-gray-200 text-gray-900
-            focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+            focus:ring-1 focus:ring-accent focus:border-accent outline-none
+            disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {availableModels.map((m) => (
-            <option key={m.value} value={m.value} className="text-black">
-              {m.label}
-            </option>
-          ))}
+          {geminiLoading
+            ? <option>Loading models...</option>
+            : availableModels.map((m) => (
+                <option key={m.value} value={m.value} className="text-black">
+                  {m.label}
+                </option>
+              ))
+          }
         </select>
 
         {/* API Key Input */}
@@ -137,6 +170,15 @@ export default function ApiKeyBar({
         <div className="mt-2 px-2.5 py-1.5 rounded-md bg-warning/10 border border-warning/20">
           <span className="text-[11px] text-warning font-medium">
             ⚠ Enter an API key to run this agent.
+          </span>
+        </div>
+      )}
+
+      {/* Gemini model fetch error */}
+      {geminiError && (
+        <div className="mt-2 px-2.5 py-1.5 rounded-md bg-warning/10 border border-warning/20">
+          <span className="text-[11px] text-warning font-medium">
+            ⚠ {geminiError}
           </span>
         </div>
       )}

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -343,3 +343,24 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
     throw error
   }
 }
+
+/**
+ * Fetch supported Gemini models dynamically from the Google API.
+ * Returns models that support generateContent (i.e. usable for chat/generation).
+ *
+ * @param {string} apiKey
+ * @returns {Promise<Array<{value: string, label: string}>>}
+ */
+export async function fetchGeminiModels(apiKey) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`
+  )
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const data = await res.json()
+  return (data.models || [])
+    .filter(m => m.supportedGenerationMethods?.includes('generateContent'))
+    .map(m => ({
+      value: m.name.replace('models/', ''),
+      label: m.displayName || m.name.replace('models/', ''),
+    }))
+}


### PR DESCRIPTION
## What does this PR do?

Replaces the hardcoded Gemini model list with dynamic fetching from Google's `/v1beta/models` API, so users with valid but newer API keys no longer hit 404/provider errors caused by deprecated or restricted model identifiers.

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist
**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #180
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [[lucide.dev/icons](https://lucide.dev/icons)](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)
<img width="682" height="482" alt="image" src="https://github.com/user-attachments/assets/6065002a-325d-4879-8f3f-ef242829a213" />


**Before:**
> Model dropdown shows hardcoded models (`gemini-1.5-flash`, `gemini-2.0-flash-exp`, etc.) regardless of what the API key actually supports — selecting any of them on a newer key results in a provider/404 error.

**After:**
> Model dropdown is empty and disabled with `"Loading models..."` while fetching. Once the API responds, it populates with only the models your specific API key has access to, and the first one is auto-selected. If the key is invalid, a warning banner appears: `"Could not load Gemini models. Check your API key."`

## Anything else I should know?

Only 2 files were changed — `llmAdapter.js` and `ApiKeyBar.jsx`. OpenAI and Anthropic behaviour is completely untouched. The Gemini fetch is debounced by 400ms so it doesn't fire on every keystroke. The `fetchGeminiModels(apiKey)` function lives in `llmAdapter.js` alongside all other provider logic to keep things consistent with the existing architecture.