### PR TITLE
feat : Add search functionality to Sidebar component for filtering agents

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,19 @@
+import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import * as Icons from 'lucide-react'
 import agents from '../agents/registry'
 
 export default function Sidebar({ open, onClose }) {
+  const [sidebarSearchQuery, setSidebarSearchQuery] = useState('')
+
+  // Filter agents based on search query
+  const filteredAgents = agents.filter((agent) =>
+    agent.name.toLowerCase().includes(sidebarSearchQuery.toLowerCase()) ||
+    agent.category.toLowerCase().includes(sidebarSearchQuery.toLowerCase())
+  )
+
   // Group agents by category
-  const categories = agents.reduce((acc, agent) => {
+  const categories = filteredAgents.reduce((acc, agent) => {
     if (!acc[agent.category]) acc[agent.category] = []
     acc[agent.category].push(agent)
     return acc
@@ -33,8 +42,35 @@ export default function Sidebar({ open, onClose }) {
             Agents
           </span>
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-accent/10 text-accent">
-            {agents.length}
+            {filteredAgents.length}
           </span>
+        </div>
+
+        {/* Search Input */}
+        <div className="px-4 mb-2">
+          <div className="relative group">
+            <Icons.Search
+              size={14}
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400 dark:text-text-muted group-focus-within:text-accent transition-colors"
+            />
+            <input
+              type="text"
+              placeholder="Search agents..."
+              value={sidebarSearchQuery}
+              onChange={(e) => setSidebarSearchQuery(e.target.value)}
+              className="w-full pl-8 pr-8 py-1.5 text-[12px] rounded-md border transition-all
+                dark:bg-surface-hover dark:border-border dark:text-text-primary dark:focus:border-accent/40
+                bg-gray-50 border-gray-200 text-gray-900 focus:border-accent/40 focus:ring-1 focus:ring-accent/10 outline-none"
+            />
+            {sidebarSearchQuery && (
+              <button
+                onClick={() => setSidebarSearchQuery('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:text-text-muted dark:hover:text-text-primary transition-colors"
+              >
+                <Icons.X size={14} />
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Agent List */}
@@ -67,6 +103,11 @@ export default function Sidebar({ open, onClose }) {
               })}
             </div>
           ))}
+          {filteredAgents.length === 0 && (
+            <div className="px-4 py-8 text-center text-xs text-gray-400 dark:text-text-muted">
+              No agents found
+            </div>
+          )}
         </nav>
 
         {/* Footer */}


### PR DESCRIPTION
This PR adds a real-time search feature to the sidebar, allowing users to quickly find specific agents by name or category as the
  registry grows. It improves navigation efficiency, especially when users are deep within an agent's page and want to switch tools
  without returning to the homepage.

  Type of change

   - [ ] New agent
   - [ ] Bug fix
   - [x] UI improvement
   - [ ] Docs update
   - [ ] Something else (describe below)

  Checklist

  For every PR:
   - [x] I was assigned to this issue before starting
   - [x] I have read CONTRIBUTING.md
   - [x] This PR is linked to issue #
   - [x] I tested this locally with npm run dev (Verified via npm run build)
   - [x] No API keys are anywhere in my code
   - [x] I did not add any new packages without discussing it first

  Screenshots (optional)
  Before:
  The sidebar listed all agents grouped by category with no way to filter, requiring significant scrolling as the number of agents
  increased.

  After:
  A sticky search bar is now present at the top of the sidebar. Typing in it filters the list in real-time, hides categories with no
  matches, and updates the agent count badge. A "No agents found" message appears if there are no matches.
  
<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/344e9ac3-374a-46b3-a156-ffcbf109ee2a" />


  Anything else I should know?

  The search matches against both the agent name and the category name, making it easy to find all "Engineering" tools or a specific
  "Code Reviewer" tool. The UI matches the existing dark/light mode styles perfectly.
  
  solves #194 