### PR TITLE
Added live charCounter

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -14,6 +14,7 @@ import {
 import ApiKeyBar from "./ApiKeyBar";
 import OutputRenderer from "./OutputRenderer";
 import ErrorCard from "./ErrorCard";
+import CharCounter from "./CharCounter";
 import VoiceInput from "./VoiceInput";
 import { useApiKey } from "../lib/useApiKey";
 import { streamAgent } from "../lib/llmAdapter";
@@ -330,12 +331,14 @@ export default function AgentRunner({ agent }) {
                     bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
                     focus:ring-1 focus:ring-accent focus:border-accent outline-none"
                 />
+                 
                 <VoiceInput
                   value={inputs[input.id] || ""}
                   onChange={(v) => updateInput(input.id, v)}
                   className="top-1/2 -translate-y-1/2 right-1.5"
                 />
               </div>
+              
             )}
 
             {input.type === "textarea" && (
@@ -355,6 +358,10 @@ export default function AgentRunner({ agent }) {
                   onChange={(v) => updateInput(input.id, v)}
                   className="top-2 right-2"
                 />
+                <CharCounter
+      value={inputs[input.id] || ""}
+      maxLength={5000}
+    />
               </div>
             )}
 
@@ -376,6 +383,10 @@ export default function AgentRunner({ agent }) {
                   onChange={(v) => updateInput(input.id, v)}
                   className="top-2 right-2"
                 />
+                <CharCounter
+      value={inputs[input.id] || ""}
+      maxLength={5000}
+    />
               </div>
             )}
 
@@ -479,9 +490,10 @@ export default function AgentRunner({ agent }) {
                 System Prompt
               </label>
               <div className="flex items-center gap-2">
-                <span className="text-[10px] dark:text-text-muted text-gray-400">
-                  {customPrompt.length} chars
-                </span>
+                <CharCounter
+  value={customPrompt}
+  maxLength={5000}
+/>
                 {isPromptModified && (
                   <button
                     onClick={() => setCustomPrompt(agent.systemPrompt)}

--- a/src/components/CharCounter.jsx
+++ b/src/components/CharCounter.jsx
@@ -1,0 +1,9 @@
+const CharCounter = ({ value = "", maxLength = 5000 }) => {
+  return (
+    <p className="mt-1 text-[11px] text-gray-400 dark:text-text-muted">
+      {value.length} / {maxLength} characters
+    </p>
+  );
+};
+
+export default CharCounter;


### PR DESCRIPTION
## What does this PR do?

Adds a reusable `CharCounter.jsx` component and integrates live character count feedback into textarea and code input fields in `AgentRunner.jsx`. This improves UX by helping users track prompt/input size against API limits in real time.

## Type of change

* [ ] New agent
* [ ] Bug fix
* [x] UI improvement
* [ ] Docs update
* [ ] Something else (describe below)

## Checklist

**For every PR:**

* [x] I was assigned to this issue before starting
* [x] I have read CONTRIBUTING.md
* [x] This PR is linked to issue #<181>
* [x] I tested this locally with `npm run dev`
* [x] No API keys are anywhere in my code
* [x] I did not add any new packages without discussing it first

**For new agent PRs:**

* [ ] I tested the agent with a real API key
* [ ] I created a new file in `src/agents/definitions/` with the agent config
* [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
* [ ] The icon name is from [[lucide.dev/icons](https://lucide.dev/icons)](https://lucide.dev/icons)
* [ ] The system prompt clearly describes the format of the output
* [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

<img width="695" height="389" alt="image" src="https://github.com/user-attachments/assets/8a8053ab-c401-4ea5-b957-f8f60d36e707" />

**Before:**
No live character count was displayed below textarea inputs.

**After:**
Live character counters now display in `342 / 5000 characters` format below textarea, code, and prompt input fields.

## Anything else I should know?

Implemented using lightweight logic with `value.length` only. No additional libraries or dependencies were added.