### PR TITLE
feat: add Typography Pairer agent to Design category

### DIFF
--- a/src/agents/definitions/typography-pairer.js
+++ b/src/agents/definitions/typography-pairer.js
@@ -1,0 +1,105 @@
+export default {
+  id: "typography-pairer",
+  createdAt: "2025-05-22",
+  name: "Typography Pairer",
+  description:
+    "Describe your project mood, brand, or use case and get 3-5 font pairings with heading, body, and accent fonts, live CSS snippets, and Tailwind config.",
+  category: "Design",
+  icon: "Type",
+  provider: "any",
+  defaultProvider: "openai",
+  model: "gpt-4o",
+  exampleInputs: {
+    description: "A luxury skincare brand website that feels premium and editorial.",
+    mood: "Luxury",
+    outputFormat: "CSS custom properties",
+  },
+  inputs: [
+    {
+      id: "description",
+      label: "Describe your project or use case",
+      type: "textarea",
+      placeholder:
+        "e.g. A minimal SaaS dashboard for developers / A warm editorial food blog / A luxury e-commerce brand",
+      required: true,
+    },
+    {
+      id: "mood",
+      label: "Mood / vibe",
+      type: "select",
+      options: [
+        "Editorial",
+        "Minimal",
+        "Bold",
+        "Playful",
+        "Luxury",
+        "Technical",
+        "Warm",
+        "Corporate",
+      ],
+      defaultValue: "Minimal",
+      required: true,
+    },
+    {
+      id: "outputFormat",
+      label: "Code format",
+      type: "select",
+      options: [
+        "CSS custom properties",
+        "Tailwind config",
+        "Both",
+      ],
+      defaultValue: "CSS custom properties",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a professional typographer and UI/UX designer specialising in web typography.
+
+Suggest 4 font pairings from Google Fonts based on the user's project description and mood.
+
+Output in this exact format:
+
+## Font Pairings
+
+For each pairing, show:
+
+### [Number]. [Pairing Name]
+> [One-sentence vibe description]
+
+**Best for:** tag1, tag2, tag3
+
+#### Preview
+- **Heading:** [Font Name] — [weight, style note]
+- **Body:** [Font Name] — [weight, style note]
+- **Accent:** [Font Name] — [optional, for captions/labels]
+
+#### Sample Text
+[Show a short heading in the heading font style]
+[Show 2 sentences of body text in the body font style]
+
+#### Code
+\`\`\`css
+@import url('https://fonts.googleapis.com/css2?family=...');
+
+h1, h2, h3 {
+  font-family: '[Heading Font]', serif;
+  font-weight: 700;
+}
+
+body, p {
+  font-family: '[Body Font]', sans-serif;
+  font-weight: 400;
+  line-height: 1.7;
+}
+\`\`\`
+
+---
+
+Rules:
+- Use only real, currently available Google Fonts
+- Each pairing must be distinctly different in personality
+- Consider both web and mobile rendering
+- If Tailwind config is requested, output fontFamily config instead of CSS
+- Recommend font-size scale: base 16px, heading scale ratio 1.25`,
+  outputType: "markdown",
+};


### PR DESCRIPTION
Adds a Typography Pairer agent to the Design category. It accepts a project description, mood/vibe, and preferred code format, then suggests 4 Google Font pairings (heading + body + accent) with CSS custom properties or Tailwind config output.

- [x] New agent
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #250
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first
- [x] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from lucide.dev/icons
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists
<img width="1919" height="982" alt="Screenshot 2026-05-23 080631" src="https://github.com/user-attachments/assets/b75990aa-bc72-4343-88ba-9b8387ac0bfb" />
<img width="1903" height="959" alt="Screenshot 2026-05-23 081432" src="https://github.com/user-attachments/assets/c05e404e-4c04-4263-b386-dcc8cd11ad4c" />
<img width="1919" height="948" alt="Screenshot 2026-05-23 081452" src="https://github.com/user-attachments/assets/d4db5ead-274f-4430-881d-4646a6fce09d" />

Tested with Gemini 2.5 Flash. Works with any provider (OpenAI, Anthropic, Gemini). The system prompt enforces structured markdown output with Preview, Sample Text, and Code sections per pairing.