### PR TITLE
Fix duplicate agent rendering in search results

### DIFF
--- a/src/agents/definitions/ml-experiment-autopsy.js
+++ b/src/agents/definitions/ml-experiment-autopsy.js
@@ -1,5 +1,5 @@
 const mlExperimentAutopsy = {
-  id: 'ml-experiment-report-generator',           
+  id: 'ml-experiment-autopsy',           
   name: 'Model Meltdown Detective',
   description: 'Diagnose failed or underperforming ML experiments using model details, dataset context, metrics, hyperparameters, and code snippets.',
   category: 'Data Science',          

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -12,4 +12,12 @@ const modules = import.meta.glob('./definitions/*.js', { eager: true });
 
 const agents = Object.values(modules).map((mod) => mod.default);
 
+const seenIds = new Set();
+agents.forEach((agent) => {
+  if (seenIds.has(agent.id)) {
+    throw new Error(`Duplicate agent ID detected: ${agent.id}`);
+  }
+  seenIds.add(agent.id);
+});
+
 export default agents;


### PR DESCRIPTION
## What does this PR do?

Closes #256 

Topic: Bug Fix
Tag: GSSoC '26
- This PR fixes duplicate agent cards appearing in search/category results by resolving a duplicate agent **id** conflict in the registry.
- It also adds a validation check in **src/agents/registry.js** to prevent future duplicate agent IDs from causing React rendering inconsistencies.

## Type of change

- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [x] Something else (describe below)

- Added duplicate-ID validation for agent registration safety.

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #256 
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots 

**Before:**

<img width="1622" height="867" alt="596273459-0fda2552-02ad-4fbe-9661-590a324903e8" src="https://github.com/user-attachments/assets/a37ef863-8436-4482-b748-e60a6315fe2f" />


**After:**

<img width="1821" height="878" alt="update_review" src="https://github.com/user-attachments/assets/8b08184e-4ddb-459d-8b07-272f92ccde07" />

## Anything else I should know?

Root cause was a duplicated top-level agent **id** shared across two agent definition files, which caused React component reuse issues during filtered rendering.
