### PR TITLE
fix: add dynamic document titles for app routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <title>I Love Agents — AI Agents, Ready to Use</title>
+    <title>I Love Agents &mdash; AI Agents, Ready to Use</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/useDocumentTitle.js
+++ b/src/lib/useDocumentTitle.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+export const SITE_NAME = 'I Love Agents'
+export const DEFAULT_TITLE = `${SITE_NAME} \u2014 AI Agents, Ready to Use`
+
+export function formatDocumentTitle(pageTitle) {
+  return pageTitle ? `${pageTitle} \u2014 ${SITE_NAME}` : DEFAULT_TITLE
+}
+
+export function useDocumentTitle(pageTitle) {
+  useEffect(() => {
+    document.title = formatDocumentTitle(pageTitle)
+  }, [pageTitle])
+}

--- a/src/pages/AgentPage.jsx
+++ b/src/pages/AgentPage.jsx
@@ -2,10 +2,12 @@ import { useEffect } from 'react'
 import { useParams, Navigate } from 'react-router-dom'
 import agents from '../agents/registry'
 import AgentRunner from '../components/AgentRunner'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 export default function AgentPage() {
   const { id } = useParams()
   const agent = agents.find((a) => a.id === id)
+  useDocumentTitle(agent?.name ?? 'Agent')
 
   useEffect(() => {
     if (!agent) return

--- a/src/pages/BattleModeArena.jsx
+++ b/src/pages/BattleModeArena.jsx
@@ -5,6 +5,7 @@ import { runAgent } from '../lib/llmAdapter'
 import BattleNavbar from '../components/BattleNavbar'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 const PROVIDERS = [
   {
@@ -63,6 +64,7 @@ export default function BattleModeArena() {
   const navigate = useNavigate()
   const location = useLocation()
   const { agent, inputs, apiKeys } = location.state || {}
+  useDocumentTitle(agent?.name ? `${agent.name} Battle` : 'Battle Arena')
 
   const [results, setResults] = useState({
     openai: { loading: true, content: null, error: null, duration: null },

--- a/src/pages/BattleModeLanding.jsx
+++ b/src/pages/BattleModeLanding.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Swords, ArrowLeft, Crosshair, PenLine, Cpu, Trophy, Bot } from 'lucide-react'
 import BattleNavbar from '../components/BattleNavbar'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 const steps = [
   { icon: Crosshair, text: 'Pick any agent', number: '01' },
@@ -17,6 +18,7 @@ const providers = [
 
 export default function BattleModeLanding() {
   const navigate = useNavigate()
+  useDocumentTitle('Battle Mode')
 
   return (
     <div className="min-h-screen bg-gray-950 text-white battle-page-transition">

--- a/src/pages/BattleModeSetup.jsx
+++ b/src/pages/BattleModeSetup.jsx
@@ -3,9 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import { Settings, Key, Swords, ArrowLeft } from 'lucide-react'
 import agents from '../agents/registry'
 import BattleNavbar from '../components/BattleNavbar'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 export default function BattleModeSetup() {
   const navigate = useNavigate()
+  useDocumentTitle('Battle Mode Setup')
   const [selectedAgentId, setSelectedAgentId] = useState('')
   const [inputs, setInputs] = useState({})
   const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '' })

--- a/src/pages/BattleModeWinner.jsx
+++ b/src/pages/BattleModeWinner.jsx
@@ -4,6 +4,7 @@ import { Trophy, Copy, Check, RotateCcw, ArrowLeft } from 'lucide-react'
 import BattleNavbar from '../components/BattleNavbar'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 const colorMap = {
   yellow: { bg: 'bg-yellow-400/10', border: 'border-yellow-400/30', text: 'text-yellow-400', hoverBorder: 'hover:border-yellow-400/60', shadow: 'hover:shadow-yellow-400/30', lightBg: 'bg-yellow-400/5' },
@@ -16,6 +17,7 @@ export default function BattleModeWinner() {
   const location = useLocation()
   const { provider, content, duration, agentName } = location.state || {}
   const [copied, setCopied] = useState(false)
+  useDocumentTitle(agentName ? `${agentName} Battle Winner` : 'Battle Winner')
 
   if (!provider || !content) {
     navigate('/battle', { replace: true })

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -6,6 +6,7 @@ import AgentCard from '../components/AgentCard'
 import { useFavorites } from '../lib/useFavorites'
 import { useHistory } from '../lib/useHistory'
 import RecentRuns from '../components/RecentRuns'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 // Derive unique sorted categories from the registry
 const allCategories = [...new Set(agents.map((a) => a.category))].sort()
@@ -31,6 +32,7 @@ export default function HomePage() {
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(null)
+  useDocumentTitle()
   
   const { favorites } = useFavorites()
   const { history, deleteRun, clearHistory } = useHistory()

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bot, Home, Swords, Search, Ghost } from 'lucide-react';
+import { useDocumentTitle } from '../lib/useDocumentTitle';
 
 export default function NotFoundPage() {
   const navigate = useNavigate();
+  useDocumentTitle('Page Not Found');
 
   return (
     <div className="min-h-[80vh] flex flex-col items-center justify-center text-center px-4 relative overflow-hidden">

--- a/src/pages/WorkflowBuilder.jsx
+++ b/src/pages/WorkflowBuilder.jsx
@@ -14,12 +14,14 @@ import {
 import * as Icons from 'lucide-react'
 import agents from '../agents/registry'
 import { saveWorkflow } from '../hooks/useWorkflows'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 const MAX_AGENTS = 5
 
 export default function WorkflowBuilder() {
   const navigate = useNavigate()
   const location = useLocation()
+  useDocumentTitle('Build a Workflow')
 
   // Pre-populate chain when navigating from a SuggestedChainPills click
   const preselected = location.state?.preselectedAgents ?? []

--- a/src/pages/WorkflowDetail.jsx
+++ b/src/pages/WorkflowDetail.jsx
@@ -15,6 +15,7 @@ import * as Icons from 'lucide-react'
 import agents from '../agents/registry'
 import { fetchWorkflowById, subscribeToWorkflow } from '../hooks/useWorkflows'
 import { supabase } from '../lib/supabase'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 function AgentRow({ agentId, index, total }) {
   const agent = agents.find((a) => a.id === agentId)
@@ -64,6 +65,7 @@ export default function WorkflowDetail() {
   const [error, setError] = useState(null)
   const [usageCount, setUsageCount] = useState(0)
   const [copied, setCopied] = useState(false)
+  useDocumentTitle(workflow?.title ?? 'Workflow Details')
 
   // Fetch workflow
   useEffect(() => {

--- a/src/pages/WorkflowLibrary.jsx
+++ b/src/pages/WorkflowLibrary.jsx
@@ -14,6 +14,7 @@ import {
 import agents from '../agents/registry'
 import { fetchWorkflows, subscribeToAllWorkflows } from '../hooks/useWorkflows'
 import { supabase } from '../lib/supabase'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 function AgentPill({ agentId }) {
   const agent = agents.find((a) => a.id === agentId)
@@ -133,6 +134,7 @@ function WorkflowCard({ workflow, onRun, onView }) {
 
 export default function WorkflowLibrary() {
   const navigate = useNavigate()
+  useDocumentTitle('Workflow Library')
   const [workflows, setWorkflows] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -22,6 +22,7 @@ import { runAgent } from '../lib/llmAdapter'
 import { resolveAgentModel, MODEL_MAP } from '../lib/resolveAgentModel'
 import { fetchWorkflowById, incrementUsage } from '../hooks/useWorkflows'
 import { exportWorkflowAsMarkdown } from '../lib/exportMarkdown'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 const STATUS_COLORS = {
   waiting: 'dark:text-text-muted text-gray-400',
@@ -90,6 +91,7 @@ export default function WorkflowRunner() {
   const [steps, setSteps] = useState([])
   const [allDone, setAllDone] = useState(false)
   const [hasRun, setHasRun] = useState(false)
+  useDocumentTitle(workflow?.title ? `Run ${workflow.title}` : 'Run Workflow')
 
   // Fetch workflow if not passed via state
   useEffect(() => {


### PR DESCRIPTION
Closes #189 
## What does this PR do?

This PR adds dynamic document titles for app routes so workflow, agent, battle, and error pages no longer keep the default home page title. This improves SEO, browser tab clarity, bookmarks, history, and accessibility.

## Type of change

- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #189
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

> No visual UI changes. This PR only updates browser tab titles.

**Before:**

Home, workflow, and agent routes all showed:
`I Love Agents — AI Agents, Ready to Use`

**After:**

Example route titles:
- `/` → `I Love Agents — AI Agents, Ready to Use`
- `/workflows` → `Workflow Library — I Love Agents`
- `/agent/bug-report-generator` → `Bug Report Generator — I Love Agents`
- `/workflows/build` → `Build a Workflow — I Love Agents`
- `*` → `Page Not Found — I Love Agents`

## Anything else I should know?

Fixes #189.

Implemented a small reusable `useDocumentTitle` hook instead of adding a new dependency. Also verified the production build with:

```bash
npm.cmd run build