### PR TITLE
feat : Implement keyboard shortcuts for agent actions and add Keyboard Shortcuts modal

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -23,6 +23,7 @@ import { useApiKey } from "../lib/useApiKey";
 import { streamAgent } from "../lib/llmAdapter";
 import { useHistory } from "../lib/useHistory";
 import { resolveAgentModel, MODEL_MAP } from "../lib/resolveAgentModel";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 const providerLabels = {
   openai: "OpenAI",
@@ -72,6 +73,16 @@ export default function AgentRunner({ agent }) {
 
   const isPromptModified = customPrompt !== agent.systemPrompt;
   const abortControllerRef = useRef(null);
+
+  useKeyboardShortcuts({
+    'Control+Enter': () => {
+      if (canRun() && !loading) handleRun();
+    },
+    'Escape': () => {
+      handleClear();
+      setPlaygroundOpen(false);
+    },
+  });
 
   useEffect(() => {
     setSelectedModel(MODEL_MAP[provider] || MODEL_MAP.openai);

--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -4,6 +4,7 @@ import { MODELS } from '../lib/resolveAgentModel'
 import openaiLogo from "../assets/openai.svg";
 import anthropicLogo from "../assets/anthropic.svg";
 import geminiLogo from "../assets/gemini.svg";
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 
 const PROVIDERS = [
   { value: 'openai', label: 'OpenAI' },
@@ -39,6 +40,21 @@ export default function ApiKeyBar({
       : PROVIDERS.filter((p) => p.value === agentProvider)
 
   const availableModels = MODELS[provider] || []
+
+  useKeyboardShortcuts({
+    'Alt+1': () => {
+      const p = availableProviders.find(p => p.value === 'openai');
+      if (p) setProvider('openai');
+    },
+    'Alt+2': () => {
+      const p = availableProviders.find(p => p.value === 'anthropic');
+      if (p) setProvider('anthropic');
+    },
+    'Alt+3': () => {
+      const p = availableProviders.find(p => p.value === 'gemini');
+      if (p) setProvider('gemini');
+    },
+  });
 
   return (
     <div className="rounded-lg border p-3 mb-4 transition-theme

--- a/src/components/KeyboardShortcutsModal.jsx
+++ b/src/components/KeyboardShortcutsModal.jsx
@@ -1,0 +1,50 @@
+import { X, Command, CornerDownLeft, Search, Type, HelpCircle } from 'lucide-react';
+
+export default function KeyboardShortcutsModal({ isOpen, onClose }) {
+  if (!isOpen) return null;
+
+  const shortcuts = [
+    { key: 'Ctrl + Enter', description: 'Run Agent or Workflow', icon: <CornerDownLeft size={14} /> },
+    { key: '/', description: 'Focus Search Bar', icon: <Search size={14} /> },
+    { key: 'Esc', description: 'Clear Inputs / Collapse Playground', icon: <X size={14} /> },
+    { key: 'Alt + 1 / 2 / 3', description: 'Toggle Provider (OpenAI, Anthropic, Gemini)', icon: <Type size={14} /> },
+    { key: '?', description: 'Open this help menu', icon: <HelpCircle size={14} /> },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-fade-in">
+      <div className="w-full max-w-md bg-white dark:bg-surface-card border border-gray-200 dark:border-border rounded-xl shadow-2xl overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-border">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-text-primary flex items-center gap-2">
+            <Command size={20} className="text-accent" />
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-900 dark:hover:text-text-primary hover:bg-gray-100 dark:hover:bg-surface-hover transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+        
+        <div className="px-6 py-4 space-y-4">
+          {shortcuts.map((s, idx) => (
+            <div key={idx} className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center text-accent">
+                  {s.icon}
+                </div>
+                <span className="text-sm font-medium text-gray-700 dark:text-text-secondary">
+                  {s.description}
+                </span>
+              </div>
+              <kbd className="px-2 py-1 text-xs font-semibold text-gray-500 bg-gray-100 border border-gray-300 rounded shadow-sm dark:bg-surface-input dark:border-border dark:text-text-muted">
+                {s.key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,10 +1,17 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { Sun, Moon, Github, Menu, X } from 'lucide-react'
+import { Sun, Moon, Github, Menu, X, HelpCircle } from 'lucide-react'
 import Logo from './Logo'
+import KeyboardShortcutsModal from './KeyboardShortcutsModal'
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 
 export default function Navbar({ sidebarOpen, setSidebarOpen }) {
   const [darkMode, setDarkMode] = useState(true)
+  const [showShortcuts, setShowShortcuts] = useState(false)
+
+  useKeyboardShortcuts({
+    '?': () => setShowShortcuts(true),
+  })
 
   useEffect(() => {
     const saved = localStorage.getItem('ila_theme')
@@ -27,60 +34,78 @@ export default function Navbar({ sidebarOpen, setSidebarOpen }) {
   }
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 h-14 flex items-center justify-between px-4 border-b transition-theme
-      dark:bg-surface dark:border-border bg-white border-gray-200">
-      {/* Left */}
-      <div className="flex items-center gap-3">
-        <button
-          onClick={() => setSidebarOpen(!sidebarOpen)}
-          className="lg:hidden p-1.5 rounded-md dark:hover:bg-surface-hover hover:bg-gray-100 transition-colors"
-          aria-label="Toggle sidebar"
-        >
-          {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
-        </button>
+    <>
+      <nav className="fixed top-0 left-0 right-0 z-50 h-14 flex items-center justify-between px-4 border-b transition-theme
+        dark:bg-surface dark:border-border bg-white border-gray-200">
+        {/* Left */}
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            className="lg:hidden p-1.5 rounded-md dark:hover:bg-surface-hover hover:bg-gray-100 transition-colors"
+            aria-label="Toggle sidebar"
+          >
+            {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
+          </button>
 
-        <Link
-          to="/"
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="flex items-center group hover:opacity-80 transition-opacity"
-        >
-          <Logo height={26} className="dark:text-white text-gray-900" />
-        </Link>
-      </div>
+          <Link
+            to="/"
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="flex items-center group hover:opacity-80 transition-opacity"
+          >
+            <Logo height={26} className="dark:text-white text-gray-900" />
+          </Link>
+        </div>
 
-      {/* Right */}
-      <div className="flex items-center gap-2">
-        <Link
-          to="/workflows"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors
-            dark:bg-surface-card dark:text-text-secondary dark:hover:text-text-primary dark:border-border
-            bg-gray-100 text-gray-600 hover:text-gray-900 border border-gray-200"
-        >
-          <span>Workflows</span>
-        </Link>
+        {/* Right */}
+        <div className="flex items-center gap-2">
+          <Link
+            to="/workflows"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors
+              dark:bg-surface-card dark:text-text-secondary dark:hover:text-text-primary dark:border-border
+              bg-gray-100 text-gray-600 hover:text-gray-900 border border-gray-200"
+          >
+            <span>Workflows</span>
+          </Link>
 
-        <a
-          href="https://github.com/AditthyaSS/iloveAgents"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors
-            dark:bg-surface-card dark:text-text-secondary dark:hover:text-text-primary dark:border-border
-            bg-gray-100 text-gray-600 hover:text-gray-900 border border-gray-200"
-        >
-          <Github size={14} />
-          <span className="hidden sm:inline">Star on GitHub</span>
-        </a>
+          <a
+            href="https://github.com/AditthyaSS/iloveAgents"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors
+              dark:bg-surface-card dark:text-text-secondary dark:hover:text-text-primary dark:border-border
+              bg-gray-100 text-gray-600 hover:text-gray-900 border border-gray-200"
+          >
+            <Github size={14} />
+            <span className="hidden sm:inline">Star on GitHub</span>
+          </a>
 
-        <button
-          onClick={toggleTheme}
-          className="p-2 rounded-md transition-colors
-            dark:hover:bg-surface-hover dark:text-text-secondary
-            hover:bg-gray-100 text-gray-500"
-          aria-label="Toggle theme"
-        >
-          {darkMode ? <Sun size={16} /> : <Moon size={16} />}
-        </button>
-      </div>
-    </nav>
+          <button
+            onClick={() => setShowShortcuts(true)}
+            className="p-2 rounded-md transition-colors
+              dark:hover:bg-surface-hover dark:text-text-secondary
+              hover:bg-gray-100 text-gray-500"
+            aria-label="Keyboard Shortcuts"
+            title="Keyboard Shortcuts (?)"
+          >
+            <HelpCircle size={16} />
+          </button>
+
+          <button
+            onClick={toggleTheme}
+            className="p-2 rounded-md transition-colors
+              dark:hover:bg-surface-hover dark:text-text-secondary
+              hover:bg-gray-100 text-gray-500"
+            aria-label="Toggle theme"
+          >
+            {darkMode ? <Sun size={16} /> : <Moon size={16} />}
+          </button>
+        </div>
+      </nav>
+      
+      <KeyboardShortcutsModal 
+        isOpen={showShortcuts} 
+        onClose={() => setShowShortcuts(false)} 
+      />
+    </>
   )
 }

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+/**
+ * A hook to handle keyboard shortcuts globally or within a component.
+ * @param {Object} shortcuts - An object where keys are shortcut descriptions (e.g., 'Control+Enter') 
+ *                             and values are callback functions.
+ */
+export const useKeyboardShortcuts = (shortcuts) => {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const keys = [];
+      if (event.ctrlKey || event.metaKey) keys.push('Control');
+      if (event.altKey) keys.push('Alt');
+      if (event.shiftKey) keys.push('Shift');
+      
+      // Don't add if it's just a modifier key
+      if (!['Control', 'Alt', 'Shift', 'Meta'].includes(event.key)) {
+        keys.push(event.key === ' ' ? 'Space' : event.key);
+      }
+
+      const shortcutStr = keys.join('+');
+      
+      // Also support single keys like '/' or '?'
+      const singleKey = event.key;
+
+      if (shortcuts[shortcutStr]) {
+        shortcuts[shortcutStr](event);
+      } else if (shortcuts[singleKey] && !['INPUT', 'TEXTAREA'].includes(event.target.tagName)) {
+        // For single keys like '/' or '?', we usually don't want them to fire if we are typing in an input
+        shortcuts[singleKey](event);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [shortcuts]);
+};

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -7,6 +7,7 @@ import { useFavorites } from '../lib/useFavorites'
 import { useHistory } from '../lib/useHistory'
 import RecentRuns from '../components/RecentRuns'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 
 // Derive unique sorted categories from the registry
 const allCategories = [...new Set(agents.map((a) => a.category))].sort()
@@ -33,6 +34,13 @@ export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(null)
   useDocumentTitle()
+
+  useKeyboardShortcuts({
+    '/': (e) => {
+      e.preventDefault();
+      document.getElementById('agent-search')?.focus();
+    },
+  });
   
   const { favorites } = useFavorites()
   const { history, deleteRun, clearHistory } = useHistory()


### PR DESCRIPTION
What does this PR do?

  This PR introduces keyboard shortcuts to iloveAgents to improve productivity for power users, enabling keyboard-driven navigation and agent execution. It adds a reusable useKeyboardShortcuts hook, a help modal accessible via ?, and several high-impact shortcuts like Ctrl+Enter to run agents and / to focus the search bar.

  Type of change

   - [ ] New agent
   - [ ] Bug fix
   - [x] UI improvement
   - [ ] Docs update
   - [x] Something else (Keyboard accessibility)

  Checklist

  For every PR:
   - [x] I was assigned to this issue before starting
   - [x] I have read CONTRIBUTING.md
   - [x] This PR is linked to issue #
   - [x] I tested this locally with npm run dev
   - [x] No API keys are anywhere in my code
   - [x] I did not add any new packages without discussing it first

  Screenshots (optional — but really helpful for UI changes)

  Before:
  The interface was entirely mouse-driven. Users had to manually click "Run Agent", clear buttons, and focus the search bar with a mouse.

  After:
   - New ? (HelpCircle) icon in the Navbar next to the theme toggle.
   - A "Keyboard Shortcuts" modal that appears when pressing ? or clicking the icon.
   - Focus rings and immediate interaction when using / or Ctrl+Enter.
   
<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/0a49cb22-add1-41a5-8d19-3bae546565e3" />

<img width="1918" height="915" alt="Screenshot 2026-05-23 134838" src="https://github.com/user-attachments/assets/dfe53edb-0395-415b-96e7-f67a2ab02b5f" />


  Anything else I should know?

  The shortcuts are implemented using a custom useKeyboardShortcuts hook that centralizes the keydown listener logic. 

  Summary of Shortcuts:
   - Ctrl + Enter: Trigger the Run Agent action (AgentRunner).
   - Esc: Clear inputs and collapse the Prompt Playground (AgentRunner).
   - /: Focus the Agent Search Bar (HomePage).
   - Alt + 1 / 2 / 3: Toggle between OpenAI, Anthropic, and Gemini (ApiKeyBar).
   - ?: Open the shortcuts help menu (Global).

  Files modified: AgentRunner.jsx, HomePage.jsx, ApiKeyBar.jsx, Navbar.jsx, and new files useKeyboardShortcuts.js,
  KeyboardShortcutsModal.jsx.
  
  fixes #193 