### PR TITLE
Add Codebase Entry Guide Agent

### DIFF
--- a/src/agents/definitions/codebase-entry-guide.js
+++ b/src/agents/definitions/codebase-entry-guide.js
@@ -1,0 +1,55 @@
+const codebaseEntryGuide = {
+  id: 'codebase-entry-guide',
+  name: 'Codebase Entry Guide Agent',
+  description: 'Understand a new codebase quickly with key files, entry points, and architecture overview.',
+  category: 'Engineering',
+  icon: 'FileSearch',
+  provider: 'any',
+  defaultProvider: 'openai',
+  model: 'gpt-4o',
+
+  inputs: [
+    {
+      id: 'repo_structure',
+      label: 'Repository Structure / Files',
+      type: 'textarea',
+      placeholder: 'Paste folder structure or key files...',
+      required: true,
+    },
+    {
+      id: 'additional_context',
+      label: 'Additional Context (optional)',
+      type: 'textarea',
+      placeholder: 'Any notes about the project...',
+      required: false,
+    },
+  ],
+
+  systemPrompt: `You are a senior software engineer helping a developer understand a new codebase quickly.
+
+Analyze the provided repository structure and context.
+
+Your output MUST include:
+
+1. 📍 Where to Start
+- Entry points (main files, index files)
+- First files to read
+
+2. 🧠 Key Components
+- Important folders and their purpose
+- Core modules explained simply
+
+3. 🏗️ High-Level Architecture
+- How the system is structured
+- How different parts connect
+
+4. 🚀 Suggested Next Steps
+- What the developer should explore next
+
+Keep explanations simple, practical, and beginner-friendly.
+Avoid jargon where possible.`,
+
+  outputType: 'markdown',
+};
+
+export default codebaseEntryGuide;


### PR DESCRIPTION
## What does this PR do?

Adds a new agent: **Codebase Entry Guide Agent** that helps developers quickly understand unfamiliar codebases by identifying entry points, key files, and providing a high-level architecture overview.

---

## Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

---

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #279 
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [x] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists

---

## Anything else I should know?

This agent is designed to improve onboarding for contributors by reducing the time required to understand a new codebase. It complements existing developer-focused agents by focusing specifically on entry-point discovery and architecture understanding.

Closes #279