### PR TITLE
fix: Search results showing duplicate agent cards instead of relevant

### DIFF
--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -26,7 +26,25 @@ export function loadAllAgents() {
   cachedAgentsPromise = Promise.all(
     Object.values(modules).map((loader) => loader())
   ).then((entries) => {
-    return entries.map((mod) => mod.default);
+    const agents = entries.map((mod) => mod.default).filter(Boolean);
+    
+    const seenIds = new Set();
+    const uniqueAgents = agents.filter((agent) => {
+      if (!agent?.id) {
+        console.warn('Skipping agent without an id:', agent);
+        return false;
+      }
+
+      if (seenIds.has(agent.id)) {
+        console.warn(`Skipping duplicate agent id "${agent.id}".`);
+        return false;
+      }
+
+      seenIds.add(agent.id);
+      return true;
+    });
+
+    return uniqueAgents;
   });
 
   return cachedAgentsPromise;

--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -27,7 +27,7 @@ export function loadAllAgents() {
     Object.values(modules).map((loader) => loader())
   ).then((entries) => {
     const agents = entries.map((mod) => mod.default).filter(Boolean);
-    
+
     const seenIds = new Set();
     const uniqueAgents = agents.filter((agent) => {
       if (!agent?.id) {


### PR DESCRIPTION
Closes #256 
## What does this PR do?

Fixes the agent directory search and category filter returning duplicate "Model Meltdown Detective" cards for unrelated queries. The root cause was a duplicate agent `id`, and this PR also adds a small registry safeguard to skip duplicate or invalid agent entries instead of rendering broken results.

## Type of change

- [ ] New agent
- [./] Bug fix
- [ ./] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [./] I have read CONTRIBUTING.md
- [./] This PR is linked to issue #256
- [./ ] I tested this locally with `npm run dev`
- [./] No API keys are anywhere in my code
- [./] I did not add any new packages without discussing it first

## Screenshots (optional — but really helpful for UI changes)

**Before:**

<img width="1622" height="867" alt="image" src="https://github.com/user-attachments/assets/8b1263e8-2dd4-42d7-9635-1ca93d1c57ab" />

**After:**

<img width="1601" height="555" alt="image" src="https://github.com/user-attachments/assets/c722515b-e634-409a-804a-b0744708dd55" />
<img width="1582" height="533" alt="image" src="https://github.com/user-attachments/assets/b6334b14-b71d-45b4-b5a4-11ba4c840184" />

## Anything else I should know?

The main fix was correcting the duplicated `id` in `ml-experiment-autopsy.js`. I also added defensive deduplication in `src/agents/registry.js` so future duplicate IDs do not silently break the directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent loading to validate agent definitions and eliminate duplicates, enhancing system reliability.

* **Chores**
  * Enhanced error reporting during agent initialization to better identify configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->