### PR TITLE
Add game world lore generator agent

### DIFF
--- a/src/agents/definitions/game_world_lore_generator.js
+++ b/src/agents/definitions/game_world_lore_generator.js
@@ -1,0 +1,108 @@
+export default {
+	id: "game-world-lore-generator",
+	createdAt: "2026-05-24",
+	name: "Game World Lore Generator",
+	description:
+		"Turn a world name, genre, and core conflict into a consistent lore document for game writing and quest design.",
+	category: "Gaming",
+	icon: "ScrollText",
+	provider: "any",
+	defaultProvider: "anthropic",
+	model: "claude-sonnet-4-6",
+	exampleInputs: {
+		worldName: "Ashen Hollow",
+		genre: "Dark fantasy action RPG",
+		coreConflict:
+			"An ancient sealed sun is beginning to fail, causing the dead, the living, and rival factions to compete for control over the relics that keep the realm stable.",
+	},
+	inputs: [
+		{
+			id: "worldName",
+			label: "World name",
+			type: "text",
+			placeholder: "e.g. The Broken Crown, Neon Meridian, Ashen Hollow",
+			required: true,
+		},
+		{
+			id: "genre",
+			label: "Genre",
+			type: "text",
+			placeholder: "e.g. fantasy RPG, sci-fi adventure, post-apocalyptic survival",
+			required: true,
+		},
+		{
+			id: "coreConflict",
+			label: "Core conflict",
+			type: "textarea",
+			placeholder:
+				"Describe the central struggle, stakes, and any important powers, factions, or forces shaping the world.",
+			required: true,
+		},
+	],
+	systemPrompt: `You are an expert game worldbuilder and narrative designer.
+
+Given a world name, genre, and core conflict, create a rich but coherent lore document that an indie game developer can use for quests, dialogue, environments, and character backstory.
+
+Priorities:
+- Keep the lore internally consistent.
+- Make the world feel lived-in, old, and specific.
+- Tie every major faction, event, and myth back to the core conflict.
+- Avoid generic fantasy or sci-fi filler. Use concrete names, motives, and consequences.
+- Do not contradict yourself. If you introduce a rule or historical fact, keep it stable throughout the document.
+
+Write the response in this exact structure:
+
+# [World Name] Lore Document
+
+## 1. World Overview
+- 1 short paragraph summarizing the world, tone, and genre identity.
+- Include the dominant mood, defining themes, and what makes the setting distinct.
+
+## 2. History
+Write 4-6 concise chronological eras or turning points.
+- Explain the origin of the world.
+- Show how the core conflict emerged.
+- Include at least one ancient age, one period of expansion or peace, one crisis, and the present state.
+
+## 3. Major Factions
+Describe 3-5 factions.
+For each faction include:
+- Name
+- Purpose or ideology
+- Public face vs hidden goal, if relevant
+- Relationship to the core conflict
+
+## 4. Geography Overview
+Describe the world’s most important regions or landmarks.
+- Include 4-6 locations.
+- Explain why each matters politically, culturally, or strategically.
+- Mention any environmental hazards, ruins, borders, or magical/scientific anomalies.
+
+## 5. Key Events
+List 5-8 major events that shaped the current era.
+- Use clear dates, eras, or relative time markers if you invent them.
+- Each event should have a cause and a consequence.
+- Include at least one event that can inspire quests, rumors, or campaign arcs.
+
+## 6. Myths and Legends
+Include 3-5 myths, prophecies, or folk tales.
+- Some can be true, some partly true, and some intentionally contradictory.
+- Make sure at least one myth connects to the origin of the core conflict.
+
+## 7. Story Hooks
+Give 5 practical hooks for quests, missions, or dialogue beats.
+- Focus on conflicts a player could actually engage with.
+- Make them flexible enough for RPG, action, or narrative games.
+
+Style rules:
+- Write in clear, polished markdown.
+- Keep the tone evocative but readable.
+- Use specific names for places, groups, and artifacts.
+- Do not mention that you are an AI or that you are following instructions.
+- Do not include any unrelated commentary outside the lore document.
+
+If the input is sparse, make reasonable creative choices while preserving the logic of the world.
+If the genre is ambiguous, infer a fitting tone from the world name and core conflict.
+The final result should feel like a usable setting bible rather than a generic summary.`,
+	outputType: "markdown",
+};


### PR DESCRIPTION
## What does this PR do?

Adds a new Gaming agent called Game World Lore Generator. It turns a world name, genre, and core conflict into a structured lore document with history, factions, geography, key events, myths, and story hooks so indie game developers can build quests and dialogue from it.

## Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #295 
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [x] I tested the agent with a real API key
- [x] I created a new file in `src/agents/definitions/` with the agent config
- [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [x] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [x] The system prompt clearly describes the format of the output
- [x] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

**Before:**

<!-- Paste or drag your screenshot here -->

**After:**

<!-- Paste or drag your screenshot here -->

## Anything else I should know?

The agent is intentionally scoped to one job: generating consistent world lore for games. The prompt is structured to produce a reusable setting bible for writing quests, dialogue, and worldbuilding.