### PR TITLE
Api keys generator guide

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -14,6 +14,7 @@ import {
   GitBranch,
 } from "lucide-react";
 import ApiKeyBar from "./ApiKeyBar";
+import ApiKeyInfo from "./ApiKeyInfo";
 import OutputRenderer from "./OutputRenderer";
 import ErrorCard from "./ErrorCard";
 import CharCounter from "./CharCounter";

--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Eye, EyeOff, ShieldCheck } from 'lucide-react'
 import { MODELS } from '../lib/resolveAgentModel'
+import ApiKeyInfo from './ApiKeyInfo'
 import openaiLogo from "../assets/openai.svg";
 import anthropicLogo from "../assets/anthropic.svg";
 import geminiLogo from "../assets/gemini.svg";
@@ -16,7 +17,13 @@ const providerLogos = {
   openai: openaiLogo,
   anthropic: anthropicLogo,
   gemini: geminiLogo,
-};
+}
+
+const providerUrls = {
+  openai: 'https://platform.openai.com/account/api-keys',
+  anthropic: 'https://console.anthropic.com/keys',
+  gemini: 'https://console.cloud.google.com/apis/credentials',
+}
 
 
 
@@ -111,11 +118,14 @@ export default function ApiKeyBar({
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
             placeholder={`Enter your ${provider} API key...`}
-            className="w-full h-8 px-3 pr-8 rounded-md text-xs font-mono transition-colors
+            className="w-full h-8 px-3 pr-10 rounded-md text-xs font-mono transition-colors
               dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
               bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
               focus:ring-1 focus:ring-accent focus:border-accent outline-none"
           />
+          <div className="absolute right-8 top-1/2 -translate-y-1/2">
+            <ApiKeyInfo provider={provider} url={providerUrls[provider]} />
+          </div>
           <button
             onClick={() => setShowKey(!showKey)}
             className="absolute right-2 top-1/2 -translate-y-1/2 dark:text-text-muted text-gray-400

--- a/src/components/ApiKeyInfo.jsx
+++ b/src/components/ApiKeyInfo.jsx
@@ -1,0 +1,20 @@
+import { Info } from "lucide-react";
+
+export default function ApiKeyInfo({ provider, url }) {
+  return (
+    <div className="relative group inline-block ml-2">
+      <Info size={16} className="cursor-pointer text-gray-400 hover:text-white" />
+      <div className="absolute z-50 hidden group-hover:block bg-black text-white text-xs rounded-md p-3 w-56 top-6 left-0 shadow-lg">
+        <p className="mb-2">Get your {provider} API key</p>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-400 underline"
+        >
+          Open {provider} dashboard
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -101,12 +101,10 @@ export default function OutputRenderer({ content, outputType, agentName, systemP
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
-code({ node, className, children, ...props }) {
-  const match = /language-(\w+)/.exec(className || '')
-  const isInline = !match && (children?.length ?? 0) < 80
-  return !isInline && match ? (
+                code({ node, className, children, ...props }) {
                   const match = /language-(\w+)/.exec(className || '')
-                  return !inline && match ? (
+                  const isInline = !match && (children?.length ?? 0) < 80
+                  return !isInline && match ? (
                     <SyntaxHighlighter
                       style={oneDark}
                       language={match[1]}

--- a/src/pages/BattleModeSetup.jsx
+++ b/src/pages/BattleModeSetup.jsx
@@ -1,6 +1,12 @@
 import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Settings, Key, Swords, ArrowLeft } from 'lucide-react'
+import ApiKeyInfo from '../components/ApiKeyInfo'
+const providerUrls = {
+  openai: 'https://platform.openai.com/account/api-keys',
+  anthropic: 'https://console.anthropic.com/keys',
+  gemini: 'https://console.cloud.google.com/apis/credentials',
+}
 import agents from '../agents/registry'
 import BattleNavbar from '../components/BattleNavbar'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
@@ -216,8 +222,9 @@ export default function BattleModeSetup() {
           </h2>
           {keyFields.map((field) => (
             <div key={field.id}>
-              <label className="block text-xs font-medium text-gray-200 mb-2">
+              <label className="block text-xs font-medium text-gray-200 mb-2 flex items-center gap-1.5">
                 {field.label}
+                <ApiKeyInfo provider={field.label.replace(/ API Key.*/, '')} url={providerUrls[field.id]} />
               </label>
               <div className="relative">
                 <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">


### PR DESCRIPTION
What does this PR do?

Added a small info (ⓘ) icon next to each API key input field that opens a tooltip or modal containing a direct link to that specific provider's API key management page. This improves user experience by making it significantly easier for users to find and generate their required keys.

Type of change

Bug fix
UI improvement
Something else (describe below)
    Added a helpful UX/UI feature (info tooltips for API links).

Checklist

[x] I was assigned to this issue before starting
[x] I have read CONTRIBUTING.md
[x] This PR is linked to issue #182
[x] I tested this locally with npm run dev
[x] No API keys are anywhere in my code
[x] I did not add any new packages without discussing it first


Screenshots (optional — but really helpful for UI changes)
<img width="1047" height="548" alt="Screenshot 2026-05-26 210310" src="https://github.com/user-attachments/assets/99e32c84-2ac3-479b-adf6-eb4afc2a9dcc" />
<img width="1181" height="390" alt="Screenshot 2026-05-26 210355" src="https://github.com/user-attachments/assets/f1280bb8-f027-474d-8b09-1af7d7e1e21c" />


Anything else I should know?
This contribution is submitted under GSSOC 2026.

All necessary repository checklists and contributing guidelines have been fulfilled.