### PR TITLE
fix: resolve duplicate agent id and invalid category causing broken search and filter

### DIFF
--- a/src/agents/definitions/ml-experiment-autopsy.js
+++ b/src/agents/definitions/ml-experiment-autopsy.js
@@ -1,8 +1,8 @@
 const mlExperimentAutopsy = {
-  id: 'ml-experiment-report-generator',           
+  id: 'ml-experiment-autopsy',           
   name: 'Model Meltdown Detective',
   description: 'Diagnose failed or underperforming ML experiments using model details, dataset context, metrics, hyperparameters, and code snippets.',
-  category: 'Data Science',          
+  category: 'Engineering',          
   icon: 'ChartSpline',              
   provider: 'any',               
   defaultProvider: 'openai',     
@@ -181,3 +181,4 @@ EDGE CASES:
 };
 
 export default mlExperimentAutopsy;
+

--- a/src/agents/definitions/ml-experiment-report-generator.js
+++ b/src/agents/definitions/ml-experiment-report-generator.js
@@ -4,7 +4,7 @@ export default {
   name: "ML Experiment Report Generator",
   description:
     "Enter your model type, hyperparameters, training metrics, and evaluation results to get a structured experiment report ready to share with your team or include in a paper.",
-  category: "Data Science",
+  category: "Engineering",
   icon: "FlaskConical",
   provider: "any",
   defaultProvider: "openai",
@@ -141,3 +141,4 @@ Rules:
 - Recommendations must be specific and actionable, not generic advice.`,
   outputType: "markdown",
 };
+


### PR DESCRIPTION
Fixes #278

## Root Cause
ml-experiment-autopsy.js had a duplicate id ('ml-experiment-report-generator') that conflicted with ml-experiment-report-generator.js, corrupting the agent registry array and causing the same wrong agent cards to render everywhere.

Both files also used 'Data Science' as the category which does not exist in the platform, breaking all category filters.

## Changes
- ml-experiment-autopsy.js: id changed from 'ml-experiment-report-generator' to 'ml-experiment-autopsy'
- ml-experiment-autopsy.js: category changed from 'Data Science' to 'Engineering'
- ml-experiment-report-generator.js: category changed from 'Data Science' to 'Engineering'

## Testing
- Tested all category filters — each returns correct agents
- Tested search with multiple keywords — results match correctly
- Result count matches rendered cards