### PR TITLE
fix(ui): standardize agent card alignment

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -59,7 +59,7 @@ export default function AgentCard({ agent }) {
   return (
     <Link
       to={`/agent/${agent.id}`}
-      className="group block rounded-lg border p-4 transition-all duration-200
+      className="group flex flex-col h-full rounded-lg border p-4 transition-all duration-200
   dark:bg-surface-card dark:border-border dark:hover:border-accent/40
   bg-white border-gray-200 hover:border-indigo-300 hover:shadow-lg hover:shadow-accent/5
   hover:-translate-y-1"    >
@@ -111,12 +111,12 @@ export default function AgentCard({ agent }) {
       <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1 group-hover:text-accent transition-colors">
         {agent.name}
       </h3>
-      <p className="text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2">
+      <p className=" flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2">
         {agent.description}
       </p>
 
       {/* Bottom: provider badge + run link */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between mt-auto">
         <span
           className={`text-[10px] font-medium px-2 py-0.5 rounded-full border ${prov.bg} ${prov.text} ${prov.border}`}
         >


### PR DESCRIPTION
Fixes inconsistent sizing and alignment issues in the agent cards UI by improving the flex layout structure inside `src/components/AgentCard.jsx`.

* [x] Bug fix

* [x] UI improvement

* [x] I was assigned to this issue before starting

* [x] I have read CONTRIBUTING.md

* [x] This PR is linked to issue #

* [x] I tested this locally with `npm run dev`

* [x] No API keys are anywhere in my code

* [x] I did not add any new packages without discussing it first

### File Updated

* `src/components/AgentCard.jsx`

### Changes Made

* Added `flex flex-col h-full` to standardize card height behavior
* Added `flex-1` to the description section for consistent stretching
* Added `mt-auto` to the footer/actions section for aligned bottom positioning

### Result

* Equal card heights
* Cleaner responsive layout
* Proper alignment across cards with varying content lengths

### Before


<img width="1366" height="768" alt="Screenshot 2026-05-18 124612" src="https://github.com/user-attachments/assets/c8398a42-f309-4a0e-b679-08d53467efa8" />

### After
<img width="1366" height="720" alt="Screenshot 2026-05-27 152015" src="https://github.com/user-attachments/assets/ff347a1b-51fd-4cb7-964d-62cbedfb8a98" />
