### PR TITLE
fix: Sidebar footer links now have proper vertical spacing from agent list (#334)

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -112,7 +112,7 @@ export default function Sidebar({ open, onClose }) {
         </nav>
 
         {/* Footer */}
-        <div className="px-4 py-3 border-t dark:border-border border-gray-200">
+        <div className="mt-auto px-4 py-3 border-t dark:border-border border-gray-200">
           <div className="space-y-1.5">
             <a
               href="https://github.com/AditthyaSS/iloveAgents"

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -112,7 +112,7 @@ export default function Sidebar({ open, onClose }) {
         </nav>
 
         {/* Footer */}
-        <div className="mt-auto px-4 py-3 border-t dark:border-border border-gray-200">
+        <div className="px-4 py-3 border-t dark:border-border border-gray-200">
           <div className="space-y-1.5">
             <a
               href="https://github.com/AditthyaSS/iloveAgents"


### PR DESCRIPTION
Fixes #334.

### Description
The sidebar footer links (GitHub ->, Contribute ->, GSSoC 2026) were crammed directly underneath the scrollable list of agents.
I have added mt-auto to the sidebar footer <div> to push it to the bottom of the flex layout.

### Testing & Screenshots
I have tested the fix locally. The footer is now pinned at the bottom.
![Screenshot](https://github.com/user-attachments/assets/7e415386-3d2a-4dd5-8b32-537e3948460c)