### PR TITLE
fix: use word-boundary-aware truncation on agent card descriptions (#335)

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -111,7 +111,7 @@ export default function AgentCard({ agent }) {
       <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1 group-hover:text-accent transition-colors">
         {agent.name}
       </h3>
-      <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 break-words">
+      <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 [overflow-wrap:anywhere]">
         {agent.description}
       </p>
 

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -111,7 +111,7 @@ export default function AgentCard({ agent }) {
       <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1 group-hover:text-accent transition-colors">
         {agent.name}
       </h3>
-      <p className=" flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2">
+      <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 break-words">
         {agent.description}
       </p>
 

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -111,11 +111,7 @@ export default function AgentCard({ agent }) {
       <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1 group-hover:text-accent transition-colors">
         {agent.name}
       </h3>
-<<<<<<< Updated upstream
-      <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 [overflow-wrap:anywhere]">
-=======
-      <p className=" flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 break-words">
->>>>>>> Stashed changes
+      <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 break-words">
         {agent.description}
       </p>
 

--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -111,7 +111,11 @@ export default function AgentCard({ agent }) {
       <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1 group-hover:text-accent transition-colors">
         {agent.name}
       </h3>
+<<<<<<< Updated upstream
       <p className="flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 [overflow-wrap:anywhere]">
+=======
+      <p className=" flex-1 text-xs dark:text-text-secondary text-gray-500 leading-relaxed mb-3 line-clamp-2 break-words">
+>>>>>>> Stashed changes
         {agent.description}
       </p>
 


### PR DESCRIPTION
Fixes #335.

### Description
Agent card descriptions were being aggressively truncated in the middle of words. I have added reak-words class in conjunction with line-clamp-2 to ensure words wrap correctly and don't get sliced in half.

### Testing & Screenshots
Tested locally on multiple cards.
![Screenshot](https://github.com/user-attachments/assets/b75990aa-bc72-4343-88ba-9b8387ac0bfb)