### PR TITLE
feat: add API key validation before agent execution

### DIFF
--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -1,5 +1,5 @@
-import { fetchGeminiModels } from '../lib/llmAdapter'
-import { useState, useEffect } from 'react'
+import { fetchGeminiModels, validateProviderKey } from '../lib/llmAdapter'
+import { useState, useEffect, useRef } from 'react'
 import { Eye, EyeOff, ShieldCheck } from 'lucide-react'
 import { MODELS } from '../lib/resolveAgentModel'
 import ApiKeyInfo from './ApiKeyInfo'
@@ -43,6 +43,12 @@ export default function ApiKeyBar({
   const [geminiModels, setGeminiModels] = useState([])
   const [geminiLoading, setGeminiLoading] = useState(false)
   const [geminiError, setGeminiError] = useState(null)
+  const [testStatusByProvider, setTestStatusByProvider] = useState({})
+  const [testMessageByProvider, setTestMessageByProvider] = useState({})
+  const [validatedKeyByProvider, setValidatedKeyByProvider] = useState({})
+  const testRequestIdRef = useRef(0)
+  const providerRef = useRef(provider)
+  const apiKeyRef = useRef(apiKey)
 
   useEffect(() => {
     if (provider !== 'gemini' || !apiKey?.trim()) {
@@ -67,6 +73,14 @@ export default function ApiKeyBar({
     return () => clearTimeout(timer)
   }, [provider, apiKey])
 
+  useEffect(() => {
+    providerRef.current = provider
+  }, [provider])
+
+  useEffect(() => {
+    apiKeyRef.current = apiKey
+  }, [apiKey])
+
   // Filter providers if agent requires a specific one
   const availableProviders =
     agentProvider === 'any'
@@ -90,6 +104,98 @@ export default function ApiKeyBar({
       if (p) setProvider('gemini');
     },
   });
+
+  const currentTestStatus = testStatusByProvider[provider]
+  const currentTestMessage = testMessageByProvider[provider]
+  const validatedKey = validatedKeyByProvider[provider]
+  const isStale = Boolean(
+    currentTestStatus === 'success' &&
+      validatedKey &&
+      apiKey &&
+      apiKey !== validatedKey
+  )
+  const displayStatus = apiKey ? (isStale ? 'stale' : currentTestStatus) : null
+  const displayMessage = apiKey
+    ? (isStale ? 'Key modified - re-test recommended.' : currentTestMessage)
+    : null
+  const isTesting = currentTestStatus === 'loading'
+  const testButtonDisabled = !apiKey?.trim() || isTesting
+
+  const handleApiKeyChange = (value) => {
+    setApiKey(value)
+
+    if (currentTestStatus === 'loading') {
+      setTestStatusByProvider((prev) => {
+        if (!prev[provider]) return prev
+        const next = { ...prev }
+        delete next[provider]
+        return next
+      })
+      setTestMessageByProvider((prev) => {
+        if (!prev[provider]) return prev
+        const next = { ...prev }
+        delete next[provider]
+        return next
+      })
+    }
+  }
+
+  const handleTestKey = async () => {
+    if (!apiKey?.trim()) return
+
+    const requestId = ++testRequestIdRef.current
+    const requestProvider = provider
+    const requestKey = apiKey
+
+    setTestStatusByProvider((prev) => ({
+      ...prev,
+      [requestProvider]: 'loading',
+    }))
+    setTestMessageByProvider((prev) => ({
+      ...prev,
+      [requestProvider]: '',
+    }))
+
+    let result
+    try {
+      result = await validateProviderKey(requestProvider, requestKey)
+    } catch {
+      result = {
+        valid: false,
+        code: 'unknown_error',
+        message: 'API key validation failed. Please try again.',
+      }
+    }
+
+    if (requestId !== testRequestIdRef.current) return
+    if (providerRef.current !== requestProvider) return
+    if (apiKeyRef.current !== requestKey) return
+
+    if (result.valid) {
+      setValidatedKeyByProvider((prev) => ({
+        ...prev,
+        [requestProvider]: requestKey,
+      }))
+      setTestStatusByProvider((prev) => ({
+        ...prev,
+        [requestProvider]: 'success',
+      }))
+      setTestMessageByProvider((prev) => ({
+        ...prev,
+        [requestProvider]: result.message || 'API key verified.',
+      }))
+      return
+    }
+
+    setTestStatusByProvider((prev) => ({
+      ...prev,
+      [requestProvider]: 'error',
+    }))
+    setTestMessageByProvider((prev) => ({
+      ...prev,
+      [requestProvider]: result.message || 'API key validation failed.',
+    }))
+  }
 
   return (
     <div className="rounded-lg border p-3 mb-4 transition-theme
@@ -149,7 +255,7 @@ export default function ApiKeyBar({
           <input
             type={showKey ? 'text' : 'password'}
             value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
+            onChange={(e) => handleApiKeyChange(e.target.value)}
             placeholder={`Enter your ${provider} API key...`}
             className="w-full h-8 px-3 pr-10 rounded-md text-xs font-mono transition-colors
               dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
@@ -168,6 +274,17 @@ export default function ApiKeyBar({
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
           </button>
         </div>
+
+        <button
+          type="button"
+          onClick={handleTestKey}
+          disabled={testButtonDisabled}
+          className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white
+            bg-accent hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed
+            transition-all duration-200 active:scale-[0.98]"
+        >
+          {isTesting ? 'Testing...' : 'Test Key'}
+        </button>
 
         {/* Save checkbox */}
         <label className="flex items-center gap-1.5 cursor-pointer select-none">
@@ -190,6 +307,29 @@ export default function ApiKeyBar({
           Your key is never sent to our servers. It's used directly from your browser.
         </span>
       </div>
+
+      {displayStatus && (
+        <div className="mt-2">
+          <span
+            className={`text-[11px] font-medium ${
+              displayStatus === 'success'
+                ? 'text-success'
+                : displayStatus === 'loading'
+                ? 'text-gray-500'
+                : displayStatus === 'error'
+                ? 'text-error'
+                : 'text-warning'
+            }`}
+          >
+            {displayStatus === 'loading'
+              ? 'Validating key...'
+              : displayMessage ||
+                (displayStatus === 'success'
+                  ? 'API key verified.'
+                  : 'API key validation failed.')}
+          </span>
+        </div>
+      )}
 
       {/* Warning if no key */}
       {!apiKey && (

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -195,6 +195,27 @@ const ERROR_MESSAGES = {
   503: 'The API service is temporarily unavailable. Try again in a minute.',
 };
 
+const PROVIDER_LABELS = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  gemini: 'Gemini',
+  openrouter: 'OpenRouter',
+}
+
+const VALIDATION_DEFAULT_MESSAGES = {
+  invalid_api_key: (label) => `Invalid ${label} API key.`,
+  quota_exceeded: (label) => `Quota exceeded or billing issue for ${label}.`,
+  network_error: () =>
+    "Couldn't reach the API. Check your internet connection and try again.",
+  unknown_error: (label) =>
+    `Unexpected error from ${label}. Check your configuration.`,
+}
+
+// Providers that sometimes return 200 OK with an error in the payload
+const VALIDATION_PAYLOAD_ERROR_PROVIDERS = new Set(['openrouter'])
+
+const ANTHROPIC_VALIDATION_MODEL = 'claude-3-5-haiku-20241022'
+
 /**
  * Handle non-OK HTTP responses consistently.
  */
@@ -224,6 +245,98 @@ async function handleErrorResponse(response, provider = "unknown") {
   throw new Error(
     detail ? `${friendlyMessage}\n\nDetails: ${detail}` : friendlyMessage
   );
+}
+
+function extractErrorMessage(payload) {
+  if (!payload) return ''
+  if (typeof payload === 'string') return payload
+  if (payload.error) {
+    if (typeof payload.error === 'string') return payload.error
+    if (typeof payload.error.message === 'string') return payload.error.message
+    return 'Unknown error'
+  }
+  if (typeof payload.message === 'string') return payload.message
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    const firstError = payload.errors[0]
+    if (typeof firstError === 'string') return firstError
+    if (typeof firstError?.message === 'string') return firstError.message
+  }
+  return ''
+}
+
+function classifyValidationError(status, detail) {
+  const normalizedDetail = (detail || '').toLowerCase()
+  if (
+    status === 401 ||
+    status === 403 ||
+    normalizedDetail.includes('invalid api key') ||
+    normalizedDetail.includes('unauthorized') ||
+    normalizedDetail.includes('authentication') ||
+    normalizedDetail.includes('api key')
+  ) {
+    return 'invalid_api_key'
+  }
+  if (
+    status === 402 ||
+    status === 429 ||
+    normalizedDetail.includes('rate limit') ||
+    normalizedDetail.includes('quota') ||
+    normalizedDetail.includes('billing')
+  ) {
+    return 'quota_exceeded'
+  }
+  return 'unknown_error'
+}
+
+function buildValidationMessage(code, provider, detail) {
+  const label = PROVIDER_LABELS[provider] || 'Provider'
+  if (code === 'network_error') {
+    return VALIDATION_DEFAULT_MESSAGES.network_error()
+  }
+  if (code === 'invalid_api_key') {
+    return VALIDATION_DEFAULT_MESSAGES.invalid_api_key(label)
+  }
+  if (code === 'quota_exceeded') {
+    return VALIDATION_DEFAULT_MESSAGES.quota_exceeded(label)
+  }
+  if (detail) return detail
+  return VALIDATION_DEFAULT_MESSAGES.unknown_error(label)
+}
+
+async function readJsonSafely(response) {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+async function normalizeValidationResponse(response, provider) {
+  if (!response.ok) {
+    const payload = await readJsonSafely(response)
+    const detail = extractErrorMessage(payload)
+    const code = classifyValidationError(response.status, detail)
+    return {
+      valid: false,
+      code,
+      message: buildValidationMessage(code, provider, detail),
+    }
+  }
+
+  if (VALIDATION_PAYLOAD_ERROR_PROVIDERS.has(provider)) {
+    const payload = await readJsonSafely(response)
+    const detail = extractErrorMessage(payload)
+    if (detail) {
+      const code = classifyValidationError(response.status, detail)
+      return {
+        valid: false,
+        code,
+        message: buildValidationMessage(code, provider, detail),
+      }
+    }
+  }
+
+  return { valid: true }
 }
 /**
  * Run an agent against the specified LLM provider (one-shot, non-streaming).
@@ -395,6 +508,106 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
       )
     }
     throw error
+  }
+}
+
+async function validateOpenAIKey(apiKey) {
+  const config = PROVIDER_CONFIGS.openai
+  const response = await fetch('https://api.openai.com/v1/models', {
+    method: 'GET',
+    headers: config.buildHeaders(apiKey),
+  })
+  return normalizeValidationResponse(response, 'openai')
+}
+
+async function validateGeminiKey(apiKey) {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+    { method: 'GET' }
+  )
+  return normalizeValidationResponse(response, 'gemini')
+}
+
+async function validateAnthropicKey(apiKey) {
+  const config = PROVIDER_CONFIGS.anthropic
+  const response = await fetch('https://api.anthropic.com/v1/models', {
+    method: 'GET',
+    headers: config.buildHeaders(apiKey),
+  })
+
+  const { status } = response
+  const normalized = await normalizeValidationResponse(response, 'anthropic')
+  if (normalized.valid) return normalized
+  if (status === 404 || status === 405) {
+    return validateAnthropicWithMessages(apiKey)
+  }
+  return normalized
+}
+
+async function validateAnthropicWithMessages(apiKey) {
+  const config = PROVIDER_CONFIGS.anthropic
+  const body = {
+    model: ANTHROPIC_VALIDATION_MODEL,
+    max_tokens: 1,
+    system: 'Validation request.',
+    messages: [{ role: 'user', content: 'ping' }],
+  }
+
+  const response = await fetch(config.url, {
+    method: 'POST',
+    headers: config.buildHeaders(apiKey),
+    body: JSON.stringify(body),
+  })
+
+  return normalizeValidationResponse(response, 'anthropic')
+}
+
+const providerValidators = {
+  openai: validateOpenAIKey,
+  anthropic: validateAnthropicKey,
+  gemini: validateGeminiKey,
+}
+
+/**
+ * Validate a provider API key using a lightweight metadata endpoint.
+ * Returns a normalized result object for UI use.
+ */
+export async function validateProviderKey(provider, apiKey) {
+  if (!apiKey || apiKey.trim() === '') {
+    return {
+      valid: false,
+      code: 'invalid_api_key',
+      message: 'API key is required.',
+    }
+  }
+
+  const validator = providerValidators[provider]
+  if (!validator) {
+    return {
+      valid: false,
+      code: 'unknown_error',
+      message: `Unsupported provider: ${provider}`,
+    }
+  }
+
+  try {
+    return await validator(apiKey)
+  } catch (error) {
+    if (error?.name === 'TypeError' && error?.message === 'Failed to fetch') {
+      return {
+        valid: false,
+        code: 'network_error',
+        message: buildValidationMessage('network_error', provider, ''),
+      }
+    }
+
+    return {
+      valid: false,
+      code: 'unknown_error',
+      message:
+        error?.message ||
+        buildValidationMessage('unknown_error', provider, ''),
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR adds manual API key validation before agent execution to improve provider setup UX and reduce failed runs caused by invalid credentials.

## Changes made
Added a "Test Key" action inside the API Key bar
Added lightweight provider-specific validation requests:
OpenAI → /v1/models
Gemini → /v1beta/models
Anthropic → /v1/models with fallback validation handling
Added normalized validation responses for provider-agnostic UI feedback
Added inline loading, success, stale, and error validation states
Added race-safe async handling to prevent stale validation updates
Prevented unnecessary validation requests unless explicitly triggered
Preserved validation status per provider
Added safer error normalization and network failure handling

Fixes #357 

## Type of change

- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Docs update
- [x] Something else (describe below)
Feature enhancement

## Checklist

**For every PR:**
- [x] I was assigned to this issue before starting
- [x] I have read CONTRIBUTING.md
- [x] This PR is linked to issue #357 
- [x] I tested this locally with `npm run dev`
- [x] No API keys are anywhere in my code
- [x] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

**Before:**

<img width="1440" height="777" alt="Screenshot 2026-05-28 at 12 48 09" src="https://github.com/user-attachments/assets/f7866eca-e607-4c1d-81d6-c5afbd0ecafc" />


**After:**

For Vaild API :

<img width="1440" height="777" alt="Screenshot 2026-05-28 at 12 36 14" src="https://github.com/user-attachments/assets/628335c7-b636-4c82-ac62-c9711089c82d" />


For Invalid API : 

<img width="1440" height="779" alt="Screenshot 2026-05-28 at 12 36 28" src="https://github.com/user-attachments/assets/6e90db1d-3065-4867-af71-94c352989b1d" />


## Anything else I should know?

This implementation intentionally keeps validation manual-only to avoid unnecessary provider requests, accidental API spam while typing, and potential rate-limit issues.
