### PR TITLE
Fix provider context in streamAgent error handling

### DIFF
--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -335,7 +335,7 @@ export async function streamAgent({ provider, model, apiKey, systemPrompt, userM
     })
 
     if (!response.ok) {
-      await handleErrorResponse(response)
+      await handleErrorResponse(response, provider)
     }
 
     const reader = response.body.getReader()


### PR DESCRIPTION
## Summary
- Passed the missing `provider` argument to `handleErrorResponse` inside `streamAgent`
- Keeps streaming error handling consistent with `runAgent`
- Allows provider-specific invalid API key errors to show the correct provider context

## Related Issue
Closes #363

## Testing
- Ran `npm run build`
- Confirmed the production build completes successfully