### PR TITLE
Delay object URL revocation for output downloads

### DIFF
--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -57,7 +57,7 @@ function DownloadButton({ text, agentName }) {
     a.href = url
     a.download = `${agentName || 'output'}.txt`
     a.click()
-    URL.revokeObjectURL(url)
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
   }
 
   return (


### PR DESCRIPTION
## Summary
- Delayed object URL cleanup after triggering output downloads
- Prevents premature `URL.revokeObjectURL` calls from breaking downloads in Firefox and Safari
- Keeps cleanup in place to avoid leaking object URLs

## Related Issue
Closes #364

## Testing
- Ran `npm run build`
- Confirmed the production build completes successfully