### PR TITLE
feat: add Crammo Mnemonic Generator agent

### DIFF
--- a/src/agents/definitions/mnemonic-generator.js
+++ b/src/agents/definitions/mnemonic-generator.js
@@ -1,0 +1,54 @@
+export default {
+  id: "mnemonic-generator",
+  createdAt: "2026-06-04",
+  name: "Crammo: Mnemonic Generator", 
+  description: 
+    "Paste study material and get revision friendly mnemonics.",
+  category: "Education",
+  icon: "Brain",
+  provider: "any",
+  defaultProvider: "gemini", 
+  model: "gemini-3.1-flash-lite", 
+  exampleInputs: {
+    source_material: "The order of planets from the Sun: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune",
+  focus_area: "Make it funny and easy to remember"
+  },
+    inputs: [
+  {
+    id: "source_material",
+    label: "Paste your study material here", 
+    type: "textarea",
+    placeholder: "Paste your study material here for a mnemonic to ace that exam! ", 
+    required: true
+  }, 
+  {
+    id: "focus_area", 
+    label: "Custom Instruction (Optional)" , 
+    type: "text",
+    placeholder: "e.g. Focus only on key dates...",
+    required: false
+}, 
+], 
+  systemPrompt: `You are an expert mnemonic generator. Your main task is to help students remember topics and revise using mnemonics. 
+  You are to generate the mnemonic exclusively from what the student has pasted under the source material. 
+  In generation of the mnemonic use the source materials the student has provided to you. 
+  Make sure the mnemonic is created using simple English vocabulary words that the student can recall in the exam. 
+  Refer to the mnemonic generation guide below to understand the generation of mnemonics. 
+
+Mnemonic Generation Guide: 
+Consider what critical information you need to remember and how you can be creative.
+Example:  For my astronomy class, I need to remember the order of planets from the Sun: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune
+Take the first letter (or a key word) of the item you need to remember and write it down. Repeat for all items.
+Example:  M, V, E, M, J, S, U, N
+Create a phrase or a sentence that incorporates the first letters (or key words). Pick the first thing that pops into your head – it doesn’t have to make sense!
+Example:  My Very Educated Mother Just Served Us Nachos  
+
+
+After you generate the mnemonic, provide it in a readable format so that the student can remember it with ease.`,
+outputType : "markdown" 
+
+};
+    
+  
+  
+  


### PR DESCRIPTION
What does this PR do?
---
Adds the Crammo Mnemonic Generator agent under the Education category. It takes study material as input and generates memorable mnemonics using acronyms and phrases to help students revise and retain information faster.


Type of change
-----
New agent


Checklist
For every PR:
---

 I was assigned to this issue before starting: **yes** 
 I have read CONTRIBUTING.md: **yes**
 This PR is linked to issue **#383**
 I tested this locally with npm run dev: **yes through github codespaces**
 No API keys are anywhere in my code: **yes checked**
 I did not add any new packages without discussing it first: **yes**
 Closes #383 


For new agent PRs:
---

 I tested the agent with a real API key: **yes**
 I created a new file in src/agents/definitions/ with the agent config: **yes**
 The agent id is lowercase and uses kebab-case (like my-agent-name): **yes**
 The icon name is from [lucide.dev/icons](https://lucide.dev/icons): **yes**
 The system prompt clearly describes the format of the output: **yes**
 This agent is not a duplicate of one that already exists: **yes**

Anything else I should know?
---
This is the first of three Crammo agents (Mnemonic Generator, Cheatsheet Generator, Study Mindmap Generator) being added as part of issue #383. The cheatsheet and mindmap agents will follow in subsequent PRs after review feedback on this one. Tested via GitHub Codespaces with a real Gemini API key.