### PR TITLE
feat: add On-Call Handoff Note Generator agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # 🤖 Available Agents
 
-34 agents and growing — built by the community. 🚀
+35 agents and growing — built by the community. 🚀
 
 | # | Agent | What It Does | Category |
 |---|-------|-------------|----------|
@@ -38,4 +38,5 @@
 | 32 | Accessibility Audit Generator | Paste your HTML and get a detailed WCAG audit with issues, severity ratings, and fixes | Engineering |
 | 33 | Personal Budget Analyzer | Analyze monthly income and expenses to get savings rate, benchmarks, and financial recommendations | Finance |
 | 34 | K8s Manifest Generator | Generates a full Kubernetes manifest from your app name, container image, port, and optional config | DevOps |
+| 35 | On-Call Handoff Note Generator | Generates a structured handoff note from current system status, ongoing incidents, and recent deployments | DevOps |
 > Want to add your own? It takes about 5 minutes. See [Contributing](#contributing) below.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ src/
 │   ├── definitions/          # Each agent in its own file (auto-collected)
 │   │   ├── pdf-summarizer.js
 │   │   ├── code-reviewer.js
-│   │   └── ... (33 files)
+│   │   └── ... (35 files)
 │   ├── categories.js         # CATEGORIES constant
 │   └── registry.js           # Auto-collects all definitions via import.meta.glob
 ├── components/

--- a/src/agents/definitions/on-call-handoff-note-generator.js
+++ b/src/agents/definitions/on-call-handoff-note-generator.js
@@ -1,0 +1,53 @@
+export default {
+  id: "on-call-handoff-note-generator",
+  createdAt: "2026-06-05",
+  name: "On-Call Handoff Note Generator",
+  description: "Generates a structured handoff note from current system status, ongoing incidents, and recent deployments.",
+  category: "DevOps",
+  icon: "FileText",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    systemStatus: "All core services operational. Payment gateway experiencing intermittent latency.",
+    ongoingIncidents: "P3 - Database replication lag in EU-West. Team investigating.",
+    recentDeployments: "V2.4.1 deployed at 14:00. Includes hotfix for auth service."
+  },
+  inputs: [
+    {
+      id: "systemStatus",
+      label: "Current system status",
+      type: "textarea",
+      placeholder: "e.g. All services green, or API latency spikes...",
+      required: true,
+    },
+    {
+      id: "ongoingIncidents",
+      label: "Ongoing incidents",
+      type: "textarea",
+      placeholder: "e.g. None, or P2 - Payment failure...",
+      required: true,
+    },
+    {
+      id: "recentDeployments",
+      label: "Recent deployments",
+      type: "textarea",
+      placeholder: "e.g. Deployed hotfix for...",
+      required: true,
+    }
+  ],
+  systemPrompt: `You are an experienced Site Reliability Engineer (SRE) / DevOps professional handing off your on-call shift to the next person.
+
+Your task is to take the provided information and generate a clear, structured, and professional on-call handoff note.
+
+The handoff note MUST include exactly the following sections in this order:
+1. **Current State**: A summary of the system status and any ongoing incidents.
+2. **Things To Watch**: Specific services, metrics, or alerts the incoming on-call person should monitor closely, based on the recent deployments or ongoing issues.
+3. **Pending Actions**: Any follow-up tasks, investigations, or communications that need to be handled during the upcoming shift.
+4. **Escalation Contacts**: Provide a placeholder section for who to contact if things escalate (e.g., "Primary SRE: [Name/Number]").
+
+Be concise, clear, and highlight anything critical.
+
+Do not add extra sections unless necessary for clarity. Format the output using clean Markdown.`,
+  outputType: "markdown",
+};


### PR DESCRIPTION
closes #67 

## What does this PR do?

Adds a new DevOps agent, **On-Call Handoff Note Generator**, that generates structured on-call handoff notes from current system status, ongoing incidents, and recent deployments.

The generated handoff includes:

* Current State
* Things To Watch
* Pending Actions
* Escalation Contacts

Also updated the agent catalog and documentation to include the new agent.

## Type of change

* [x] New agent
* [ ] Bug fix
* [ ] UI improvement
* [x] Docs update
* [ ] Something else (describe below)

## Checklist

**For every PR:**

* [x] I was assigned to this issue before starting
* [x] I have read CONTRIBUTING.md
* [x] This PR is linked to issue #7
* [ ] I tested this locally with `npm run dev`
* [x] No API keys are anywhere in my code
* [x] I did not add any new packages without discussing it first

**For new agent PRs:**

* [ ] I tested the agent with a real API key
* [x] I created a new file in `src/agents/definitions/` with the agent config
* [x] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
* [x] The icon name is from [[lucide.dev/icons](https://lucide.dev/icons)](https://lucide.dev/icons)
* [x] The system prompt clearly describes the format of the output
* [x] This agent is not a duplicate of one that already exists


## Anything else I should know?

This PR adds the new agent definition in `src/agents/definitions/` and updates `AGENTS.md` and `README.md` to keep the documentation in sync with the repository.
Also, attempted to run locally, but encountered an existing build issue related to src/agents/registry.js default export/import mismatch. This issue appears unrelated to the new agent and was not included in this PR to keep the scope focused.