### PR TITLE
feat: add Git Branch Naming Generator agent (#54)

### DIFF
--- a/src/agents/definitions/git-branch-naming-generator.js
+++ b/src/agents/definitions/git-branch-naming-generator.js
@@ -1,0 +1,66 @@
+export default {
+  id: 'git-branch-naming-generator',
+  name: 'Git Branch Naming Generator',
+  description: 'Generate 3-5 clean, consistent branch name options from a ticket number, title, and branch type following common conventions like feature/ILA-123-add-login-page.',
+  category: 'Engineering',
+  icon: 'GitBranch',
+  provider: 'any',
+  defaultProvider: 'openai',
+  model: 'gpt-4o',
+  inputs: [
+    {
+      id: 'ticket_number',
+      label: 'Ticket Number (optional)',
+      type: 'text',
+      placeholder: 'e.g. ILA-123 or 42',
+      required: false,
+    },
+    {
+      id: 'ticket_title',
+      label: 'Ticket Title',
+      type: 'text',
+      placeholder: 'e.g. Add login page with OAuth support',
+      required: true,
+    },
+    {
+      id: 'branch_type',
+      label: 'Branch Type',
+      type: 'select',
+      options: ['feature', 'fix', 'hotfix', 'chore', 'refactor', 'docs'],
+      required: true,
+    },
+  ],
+  systemPrompt: `You are an expert software engineer who follows git branch naming best practices.
+
+Given a ticket number (optional), ticket title, and branch type, generate 3-5 branch name options following common conventions.
+
+Rules:
+- Use lowercase only
+- Replace spaces with hyphens
+- Keep it concise but descriptive (max 50 chars after the prefix)
+- Follow the pattern: type/TICKET-short-description
+- If no ticket number, use: type/short-description
+- Remove filler words (a, an, the, with, for)
+
+Output format (Markdown):
+
+## Suggested Branch Names
+
+\`\`\`
+feature/ILA-123-add-login-page
+feature/ILA-123-login-page-oauth
+feature/ILA-123-oauth-login
+feature/ILA-123-user-login-flow
+feature/ILA-123-login-oauth-support
+\`\`\`
+
+## Recommended
+**\`feature/ILA-123-add-login-page\`** — most readable and follows standard conventions.
+
+## Why these names?
+Brief explanation of the naming choices made.`,
+  outputType: 'markdown',
+}
+
+
+

--- a/src/agents/definitions/pr-description-generator.js
+++ b/src/agents/definitions/pr-description-generator.js
@@ -1,0 +1,60 @@
+export default {
+  id: 'pr-description-generator',
+  name: 'Pull Request Description Generator',
+  description: 'Turn a diff summary or bullet points of changes into a full, structured PR description with summary, changes list, testing instructions, and a screenshots section.',
+  category: 'Engineering',
+  icon: 'GitPullRequest',
+  provider: 'any',
+  defaultProvider: 'openai',
+  model: 'gpt-4o',
+  inputs: [
+    {
+      id: 'changes',
+      label: 'Changes Summary',
+      type: 'textarea',
+      placeholder: 'e.g. added login page, fixed session bug, updated readme...',
+      required: true,
+    },
+    {
+      id: 'pr_title',
+      label: 'PR Title (optional)',
+      type: 'text',
+      placeholder: 'e.g. feat: add user authentication flow',
+      required: false,
+    },
+    {
+      id: 'issue_ref',
+      label: 'Related Issue / Ticket (optional)',
+      type: 'text',
+      placeholder: 'e.g. Closes #42',
+      required: false,
+    },
+  ],
+  systemPrompt: `You are an expert software engineer who writes thorough, well-structured pull request descriptions.
+
+Given a summary of changes (could be bullet points, a git diff summary, or plain prose), generate a complete PR description in Markdown with the following sections:
+
+## Summary
+A concise 2–3 sentence overview of what this PR does and why.
+
+## Changes
+A bullet list of specific changes made (technical and clear).
+
+## Testing Instructions
+Step-by-step instructions for a reviewer to test the changes locally.
+
+## Screenshots
+A placeholder section:
+\`\`\`
+| Before | After |
+|--------|-------|
+| _(add screenshot)_ | _(add screenshot)_ |
+\`\`\`
+
+## Notes (optional)
+Any caveats, follow-up tasks, or context reviewers should know.
+
+Be specific and professional. Use the provided PR title and issue reference if given.`,
+  outputType: 'markdown',
+}
+


### PR DESCRIPTION
## Summary
Adds a Git Branch Naming Generator agent to the Engineering category.
Takes a ticket number, ticket title, and branch type as input and returns
3-5 branch name options following common conventions like feature/ILA-123-add-login-page.

## Changes
- Added `src/agents/definitions/git-branch-naming-generator.js`
- Inputs: ticket number (optional), ticket title (required), branch type select (feature/fix/hotfix/chore/refactor/docs)
- Outputs 3-5 branch name suggestions with a recommended pick and reasoning
- Works with all providers (OpenAI, Anthropic, Gemini)

## Testing Instructions
1. Run `npm install && npm run dev`
2. Open `http://localhost:5173`
3. Find "Git Branch Naming Generator" in Engineering
4. Enter ticket: `ILA-123`, title: `Add login page`, type: `feature`
5. Verify 3-5 clean branch names are returned


Closes #54