### PR TITLE
fix: replace all broken default registry imports with useAgents hook

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import * as Icons from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 
 export default function Sidebar({ open, onClose }) {
   const [sidebarSearchQuery, setSidebarSearchQuery] = useState('')
+  const { agents } = useAgents()
 
   // Filter agents based on search query
   const filteredAgents = agents.filter((agent) =>

--- a/src/components/SuggestedChainPills.jsx
+++ b/src/components/SuggestedChainPills.jsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { GitBranch } from 'lucide-react'
 import * as Icons from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 
 /**
  * Renders "Works well after" clickable pills for agents that define
@@ -12,6 +12,7 @@ import agents from '../agents/registry'
  */
 export default function SuggestedChainPills({ agent }) {
   const navigate = useNavigate()
+  const { agents } = useAgents()
 
   if (!agent.suggestedChainFrom?.length) return null
 

--- a/src/pages/AgentPage.jsx
+++ b/src/pages/AgentPage.jsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react'
 import { useParams, Navigate } from 'react-router-dom'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import AgentRunner from '../components/AgentRunner'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 export default function AgentPage() {
   const { id } = useParams()
+  const { agents } = useAgents()
   const agent = agents.find((a) => a.id === id)
   useDocumentTitle(agent?.name ?? 'Agent')
 

--- a/src/pages/BattleModeSetup.jsx
+++ b/src/pages/BattleModeSetup.jsx
@@ -1,13 +1,14 @@
 import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Settings, Key, Swords, ArrowLeft, Info, ExternalLink, ShieldCheck } from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import BattleNavbar from '../components/BattleNavbar'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 export default function BattleModeSetup() {
   const navigate = useNavigate()
   useDocumentTitle('Battle Mode Setup')
+  const { agents } = useAgents()
   const [selectedAgentId, setSelectedAgentId] = useState('')
   const [inputs, setInputs] = useState({})
   const [apiKeys, setApiKeys] = useState({ openai: '', anthropic: '', gemini: '' })

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Bot, Users, Code2, ArrowRight, Github, Search, X, SlidersHorizontal, Star, Heart, Swords, GitBranch } from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import AgentCard from '../components/AgentCard'
 import { useFavorites } from '../lib/useFavorites'
 import { useHistory } from '../lib/useHistory'
@@ -9,8 +9,7 @@ import RecentRuns from '../components/RecentRuns'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 
-// Derive unique sorted categories from the registry
-const allCategories = [...new Set(agents.map((a) => a.category))].sort()
+// Remove module-level allCategories — now derived inside the component via useAgents
 
 // Category icons/colors for the filter pills
 const categoryMeta = {
@@ -34,6 +33,13 @@ export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(null)
   useDocumentTitle()
+  const { agents } = useAgents()
+
+  // Derive unique sorted categories from the loaded agents
+  const allCategories = useMemo(
+    () => [...new Set(agents.map((a) => a.category))].sort(),
+    [agents]
+  )
 
   useKeyboardShortcuts({
     '/': (e) => {

--- a/src/pages/WorkflowBuilder.jsx
+++ b/src/pages/WorkflowBuilder.jsx
@@ -12,7 +12,7 @@ import {
   GitBranch,
 } from 'lucide-react'
 import * as Icons from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import { saveWorkflow } from '../hooks/useWorkflows'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
@@ -22,6 +22,7 @@ export default function WorkflowBuilder() {
   const navigate = useNavigate()
   const location = useLocation()
   useDocumentTitle('Build a Workflow')
+  const { agents } = useAgents()
 
   // Pre-populate chain when navigating from a SuggestedChainPills click
   const preselected = location.state?.preselectedAgents ?? []

--- a/src/pages/WorkflowDetail.jsx
+++ b/src/pages/WorkflowDetail.jsx
@@ -12,12 +12,12 @@ import {
   GitBranch,
 } from 'lucide-react'
 import * as Icons from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import { fetchWorkflowById, subscribeToWorkflow } from '../hooks/useWorkflows'
 import { supabase } from '../lib/supabase'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
-function AgentRow({ agentId, index, total }) {
+function AgentRow({ agentId, index, total, agents }) {
   const agent = agents.find((a) => a.id === agentId)
   const IconComponent = (agent && Icons[agent.icon]) || Icons.Bot
 
@@ -59,6 +59,7 @@ function AgentRow({ agentId, index, total }) {
 export default function WorkflowDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const { agents } = useAgents()
 
   const [workflow, setWorkflow] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -238,6 +239,7 @@ export default function WorkflowDetail() {
               agentId={agentId}
               index={index}
               total={workflow.agents.length}
+              agents={agents}
             />
           ))}
         </div>

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -14,7 +14,7 @@ import {
   ArrowRight,
 } from 'lucide-react'
 import * as Icons from 'lucide-react'
-import agents from '../agents/registry'
+import { useAgents } from '../lib/useAgents'
 import OutputRenderer from '../components/OutputRenderer'
 import ApiKeyBar from '../components/ApiKeyBar'
 import RunRating from '../components/RunRating'
@@ -80,6 +80,7 @@ export default function WorkflowRunner() {
   const { id } = useParams()
   const location = useLocation()
   const navigate = useNavigate()
+  const { agents } = useAgents()
 
   const { provider, setProvider, apiKey, setApiKey, saveForSession, setSaveForSession } = useApiKey()
 


### PR DESCRIPTION
## What does this PR do?

<!-- Tell me in one or two sentences what you changed and why. -->

## Type of change

- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Docs update
- [ ] Something else (describe below)

## Checklist

**For every PR:**
- [ ] I was assigned to this issue before starting
- [ ] I have read CONTRIBUTING.md
- [ ] This PR is linked to issue #
- [ ] I tested this locally with `npm run dev`
- [ ] No API keys are anywhere in my code
- [ ] I did not add any new packages without discussing it first

**For new agent PRs:**
- [ ] I tested the agent with a real API key
- [ ] I created a new file in `src/agents/definitions/` with the agent config
- [ ] The agent `id` is lowercase and uses kebab-case (like `my-agent-name`)
- [ ] The icon name is from [lucide.dev/icons](https://lucide.dev/icons)
- [ ] The system prompt clearly describes the format of the output
- [ ] This agent is not a duplicate of one that already exists

## Screenshots (optional — but really helpful for UI changes)

> If you changed anything visual, drop a before and after screenshot here.
> It helps me review faster and see exactly what changed.
> Skip this if your PR has no visual changes.

**Before:**

<!-- Paste or drag your screenshot here -->

**After:**

<!-- Paste or drag your screenshot here -->

## Anything else I should know?

<!-- Optional. Any context that would help me review this faster. -->
