### PR TITLE
feat: add API Error Message Writer agent to Engineering domain

### DIFF
--- a/src/agents/definitions/api-error-message-writer.js
+++ b/src/agents/definitions/api-error-message-writer.js
@@ -6,7 +6,7 @@ export default {
   icon: 'Terminal',
   provider: 'any',
   defaultProvider: 'openai',
-  model: 'gpt-4o',
+  model: 'gpt-4o-mini',
   inputs: [
     {
       id: 'errorCode',
@@ -39,6 +39,6 @@ You must format your entire final output as a single, valid JSON object matching
   "suggestedHttpStatus": 400
 }
 
-Ensure the "suggestedHttpStatus" field contains a real, valid 3-digit HTTP code (integer) according to RFC standards. Do not include markdown wraps or block quotes outside of the raw JSON content container.`,
+Ensure the "suggestedHttpStatus" field contains a valid standard HTTP status code integer between 100 and 599 according to RFC specifications. Output only the JSON object structure. Do not include markdown code fences, backticks, block quotes, or any surrounding conversational prose text formatting container.`,
   outputType: 'json'
 };

--- a/src/agents/definitions/api-error-message-writer.js
+++ b/src/agents/definitions/api-error-message-writer.js
@@ -1,54 +1,44 @@
 export default {
-  id: "api-error-message-writer",
-  createdAt: "2025-05-15",
-  name: "API Error Message Writer",
-  description:
-    "Generate concise and developer friendly API error messages.",
-  category: "Engineering",
-  icon: "FileCode",
-  provider: "any",
-  defaultProvider: "anthropic",
-  model: "claude-sonnet-4-6",
-  exampleInputs: {
-    errorCode:"404",
-    technicalDetails:"Requested user profile could not be found",
-  audience: "Frontend Developer",
-  },
+  id: 'api-error-message-writer',
+  name: 'API Error Message Writer',
+  description: 'Transforms technical, raw, or cryptic backend error codes and system logs into tailored, user-friendly notifications and precise diagnostic debugging steps.',
+  category: 'Engineering',
+  icon: 'Terminal',
+  provider: 'any',
+  defaultProvider: 'openai',
+  model: 'gpt-4o',
   inputs: [
     {
-      id: "errorCode",
-      label: "Error Code",
-      type: "text",
-      placeholder: "404",
-      required: true,
+      id: 'errorCode',
+      label: 'Error Code / Identifier',
+      type: 'text',
+      placeholder: 'e.g., ERR_PAYMENT_DECLINED, 503, TOKEN_EXPIRED_401',
+      required: true
     },
     {
-      id: "technicalDetails",
-      label: "Technical Details",
-      type: "textarea",
-      placeholder: "Describe the API error or technical issue",
-      required: true,
+      id: 'context',
+      label: 'Failure Context / System Log Snippet',
+      type: 'textarea',
+      placeholder: 'Describe what happened (e.g., Database connection timed out while loading user profile session cache)',
+      required: true
     },
     {
-      id: "audience",
-      label: "Audience",
-      type: "select",
-      options: [
-        "Frontend Developer",
-        "Backend Developer",
-        "Mobile Developer",
-        "End User",
-      ],
-      defaultValue: "Frontend Developer",
-      required: true,
-    },
+      id: 'audience',
+      label: 'Target Audience Profile',
+      type: 'text',
+      placeholder: 'e.g., Non-technical End User, Frontend Developer, QA Engineer',
+      required: true
+    }
   ],
-  systemPrompt: `You are an expert API error message writer.
-  Given an error code,technical details, and audience,generate a clear,professional and developer friendly API error message.
-Include:
--A user friendly error message
--A brief explanation of the cause of error
--A suggested resolution
-Keep the tone professional,concise and helpful`,
- outputType: "text",
+  systemPrompt: `You are an expert Core Infrastructure Engineer and Technical Writer specializing in API Usability and Error Handling standards. Your task is to analyze a raw error identification code, its internal infrastructure context, and a target audience profile, then compile a highly professional response mapping system.
+
+You must format your entire final output as a single, valid JSON object matching the schema below:
+{
+  "userFriendlyMessage": "A clear, empathetic, action-oriented message explaining the scenario to the defined audience, completely void of raw logs, query syntax, or database terminology.",
+  "developerTechnicalMessage": "A precise breakdown detailing exact system fault strings, root components involved, and concrete step-by-step diagnostic actions for an engineering team.",
+  "suggestedHttpStatus": 400
+}
+
+Ensure the "suggestedHttpStatus" field contains a real, valid 3-digit HTTP code (integer) according to RFC standards. Do not include markdown wraps or block quotes outside of the raw JSON content container.`,
+  outputType: 'json'
 };


### PR DESCRIPTION
## What does this PR do?
Closes #53 
Implements the self-contained configuration object for the `API Error Message Writer` agent, assigning it to the Engineering domain. The agent takes an error code, system context, and target audience profile as inputs, processing them to output a structured JSON response containing user-friendly copy, technical developer logs, and an RFC-compliant suggested HTTP status code.

## Type of change
- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
NA
### Localhost Verification
*Verified agent successfully self-registering under the Engineering category sidebar list and rendering input containers flawlessly.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error message writer now returns strict JSON containing userFriendlyMessage, developerTechnicalMessage, and suggestedHttpStatus.
  * Output enforces a valid HTTP status code (100–599) and JSON-only formatting.
* **Inputs**
  * Updated inputs: a context textarea and a free-form audience field for clearer error context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->