### PR TITLE
feat: replace suite emojis with Lucide icons

### DIFF
--- a/src/components/SuiteWizard.jsx
+++ b/src/components/SuiteWizard.jsx
@@ -1,7 +1,17 @@
 import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowLeft, ArrowRight, SkipForward, Sparkles } from 'lucide-react'
+import {
+  ArrowLeft, ArrowRight, SkipForward, Sparkles,
+  Code2, BarChart3, TrendingUp, DollarSign, Palette,
+  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
+} from 'lucide-react'
 import { useAgents } from '../lib/useAgents'
+
+// Map icon name string → Lucide component
+const SUITE_ICONS = {
+  Code2, BarChart3, TrendingUp, DollarSign, Palette,
+  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
+}
 
 /**
  * SuiteWizard
@@ -94,6 +104,7 @@ export default function SuiteWizard({ suite, onBack }) {
   if (showResults) {
     const matched = rankedAgents.filter((r) => r.pct > 0)
     const unmatched = rankedAgents.filter((r) => r.pct === 0)
+    const SuiteIcon = SUITE_ICONS[suite.icon] || Code2
 
     return (
       <div className="animate-fade-in">
@@ -107,15 +118,18 @@ export default function SuiteWizard({ suite, onBack }) {
           >
             <ArrowLeft size={16} />
           </button>
-          <div>
-            <h2 className="text-lg font-bold dark:text-text-primary text-gray-900">
-              {suite.emoji} {suite.name}
-            </h2>
-            <p className="text-xs dark:text-text-muted text-gray-400">
-              {answeredCount > 0
-                ? `Recommended based on your answers`
-                : 'All agents in this suite'}
-            </p>
+          <div className="flex items-center gap-2">
+            <SuiteIcon size={18} style={{ color: suite.color }} />
+            <div>
+              <h2 className="text-lg font-bold dark:text-text-primary text-gray-900">
+                {suite.name}
+              </h2>
+              <p className="text-xs dark:text-text-muted text-gray-400">
+                {answeredCount > 0
+                  ? `Recommended based on your answers`
+                  : 'All agents in this suite'}
+              </p>
+            </div>
           </div>
         </div>
 
@@ -183,6 +197,7 @@ export default function SuiteWizard({ suite, onBack }) {
   // ─────────────────────────────────────────────────────
   const question = questions[step]
   const progress = questions.length > 0 ? ((step) / questions.length) * 100 : 0
+  const SuiteIcon = SUITE_ICONS[suite.icon] || Code2
 
   return (
     <div className="max-w-xl mx-auto animate-fade-in">
@@ -196,13 +211,16 @@ export default function SuiteWizard({ suite, onBack }) {
         >
           <ArrowLeft size={16} />
         </button>
-        <div>
-          <h2 className="text-base font-bold dark:text-text-primary text-gray-900">
-            {suite.emoji} {suite.name}
-          </h2>
-          <p className="text-xs dark:text-text-muted text-gray-400">
-            Question {step + 1} of {questions.length}
-          </p>
+        <div className="flex items-center gap-2">
+          <SuiteIcon size={16} style={{ color: suite.color }} />
+          <div>
+            <h2 className="text-base font-bold dark:text-text-primary text-gray-900">
+              {suite.name}
+            </h2>
+            <p className="text-xs dark:text-text-muted text-gray-400">
+              Question {step + 1} of {questions.length}
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/pages/SuitesPage.jsx
+++ b/src/pages/SuitesPage.jsx
@@ -1,9 +1,15 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Sparkles, ArrowRight } from 'lucide-react'
+import { Sparkles, ArrowRight, Code2, BarChart3, TrendingUp, DollarSign, Palette, PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2 } from 'lucide-react'
 import { suites } from '../suites/suitesData'
 import SuiteWizard from '../components/SuiteWizard'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
+
+// Map icon name string → Lucide component
+const SUITE_ICONS = {
+  Code2, BarChart3, TrendingUp, DollarSign, Palette,
+  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
+}
 
 /**
  * SuitesPage
@@ -71,6 +77,7 @@ export default function SuitesPage() {
 
 // ── Suite card
 function SuiteCard({ suite, onSelect }) {
+  const IconComponent = SUITE_ICONS[suite.icon] || Code2
   return (
     <div
       className="rounded-xl border p-5 flex flex-col gap-3 transition-all duration-200
@@ -78,11 +85,14 @@ function SuiteCard({ suite, onSelect }) {
         hover:shadow-md hover:-translate-y-0.5"
       style={{ borderTopColor: suite.color, borderTopWidth: 3 }}
     >
-      {/* Emoji + name */}
-      <div className="flex items-center gap-2">
-        <span className="text-2xl" role="img" aria-label={suite.name}>
-          {suite.emoji}
-        </span>
+      {/* Icon + name */}
+      <div className="flex items-center gap-2.5">
+        <div
+          className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+          style={{ backgroundColor: suite.color + '20' }}
+        >
+          <IconComponent size={17} style={{ color: suite.color }} />
+        </div>
         <h2 className="text-base font-bold dark:text-text-primary text-gray-900 leading-tight">
           {suite.name}
         </h2>

--- a/src/suites/suitesData.js
+++ b/src/suites/suitesData.js
@@ -2,7 +2,7 @@ export const suites = [
   {
     id: 'developer',
     name: 'Developer Suite',
-    emoji: '💻',
+    icon: 'Code2',
     description: 'Everything you need to write, review, and ship better code',
     color: '#6366f1',
     agents: [
@@ -58,7 +58,7 @@ export const suites = [
   {
     id: 'data-ai',
     name: 'Data & AI Suite',
-    emoji: '📊',
+    icon: 'BarChart3',
     description: 'Build, analyze, and optimize your data pipelines and ML models',
     color: '#0ea5e9',
     agents: [
@@ -92,7 +92,7 @@ export const suites = [
   {
     id: 'marketing',
     name: 'Marketing & Growth Suite',
-    emoji: '📈',
+    icon: 'TrendingUp',
     description: 'Create content, grow your audience, and drive more traffic',
     color: '#f59e0b',
     agents: [
@@ -123,7 +123,7 @@ export const suites = [
   {
     id: 'sales',
     name: 'Sales Suite',
-    emoji: '💰',
+    icon: 'DollarSign',
     description: 'Close more deals with better outreach, scripts, and analysis',
     color: '#10b981',
     agents: [
@@ -153,7 +153,7 @@ export const suites = [
   {
     id: 'design-creative',
     name: 'Design & Creative Suite',
-    emoji: '🎨',
+    icon: 'Palette',
     description: 'Design better products, generate worlds, and build stunning UIs',
     color: '#ec4899',
     agents: [
@@ -181,7 +181,7 @@ export const suites = [
   {
     id: 'content-writing',
     name: 'Content & Writing Suite',
-    emoji: '📝',
+    icon: 'PenLine',
     description: 'Write proposals, documents, and content that gets results',
     color: '#8b5cf6',
     agents: [
@@ -212,7 +212,7 @@ export const suites = [
   {
     id: 'learning-career',
     name: 'Learning & Career Suite',
-    emoji: '🎓',
+    icon: 'GraduationCap',
     description: 'Learn faster, grow your career, and land your dream job',
     color: '#f97316',
     agents: [
@@ -243,7 +243,7 @@ export const suites = [
   {
     id: 'business',
     name: 'Business Suite',
-    emoji: '🏢',
+    icon: 'Briefcase',
     description: 'Run your business smarter with legal, finance, and operations tools',
     color: '#64748b',
     agents: [
@@ -277,7 +277,7 @@ export const suites = [
   {
     id: 'health',
     name: 'Health & Wellness Suite',
-    emoji: '🏥',
+    icon: 'HeartPulse',
     description: 'Tools for healthcare professionals and personal wellness',
     color: '#ef4444',
     agents: [
@@ -302,7 +302,7 @@ export const suites = [
   {
     id: 'security-web3',
     name: 'Security & Web3 Suite',
-    emoji: '🔐',
+    icon: 'ShieldCheck',
     description: 'Audit smart contracts, detect threats, and build on Web3',
     color: '#14b8a6',
     agents: [
@@ -328,7 +328,7 @@ export const suites = [
   {
     id: 'gaming',
     name: 'Gaming & Fun Suite',
-    emoji: '🎮',
+    icon: 'Gamepad2',
     description: 'Build game worlds, check compatibility, and explore your future',
     color: '#a855f7',
     agents: [


### PR DESCRIPTION
## What does this PR do?
<!-- Describe your changes clearly -->

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [ ] I did not break any existing agents ✅
- [ ] I did not use `import agents from '../agents/registry'` ✅
- [ ] My PR has a clear description above ✅

## Screenshots (if UI change)
<!-- Add screenshots here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced emoji-based suite representations with a centralized icon system throughout the app for improved visual polish.
  * Suite icons now display with themed colors across suite cards and wizard views (results and quiz headers).
  * Enhanced visual consistency with fallback icon support for all suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->