### PR TITLE
fix: Add React Error Boundaries to OutputRenderer (Fixes #304)

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -22,6 +22,7 @@ import CharCounter from "./CharCounter";
 import VoiceInput from "./VoiceInput";
 import SuggestedChainPills from "./SuggestedChainPills";
 import RunRating from "./RunRating";
+import ErrorBoundary from "./ErrorBoundary";
 import { useApiKey } from "../lib/useApiKey";
 import { streamAgent } from "../lib/llmAdapter";
 import { useHistory } from "../lib/useHistory";
@@ -684,12 +685,14 @@ export default function AgentRunner({ agent }) {
 
       {output && !isStreaming && (
         <div className="space-y-4">
-          <OutputRenderer
-            content={output}
-            outputType={agent.outputType}
-            agentName={agent.name}
-            systemPrompt={customPrompt}
-          />
+          <ErrorBoundary>
+            <OutputRenderer
+              content={output}
+              outputType={agent.outputType}
+              agentName={agent.name}
+              systemPrompt={customPrompt}
+            />
+          </ErrorBoundary>
           <RunRating />
           <div className="flex justify-end">
             <button

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-xl my-4 text-center">
+          <AlertTriangle className="mx-auto text-red-400 mb-4" size={48} />
+          <h3 className="text-xl font-bold text-red-400 mb-2">Failed to render output</h3>
+          <p className="text-gray-300 text-sm mb-4">
+            The AI generated content that our renderer could not process.
+          </p>
+          <pre className="text-left bg-gray-900/50 p-4 rounded-lg text-xs text-red-300 overflow-x-auto whitespace-pre-wrap">
+            {this.state.error?.toString() || 'Unknown rendering error'}
+          </pre>
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            className="mt-4 px-4 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-300 rounded-lg transition-colors text-sm font-medium"
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Description - Wraps the OutputRenderer in an ErrorBoundary to gracefully handle markdown parsing crashes. Fixes #304. %0A## Pillar - Reliability %0A## Checklist - Tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error handling for output rendering. When rendering fails, users now see an error message and "Try Again" button instead of a broken interface, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->