### PR TITLE
fix: complete sidebar agent search (whitespace-tolerant matching + a11y labels)

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,9 +17,12 @@ export default function Sidebar({ open, onClose }) {
   }, [])
 
   // Filter agents based on search query
+  // Normalize the query (trim + lowercase) so matching is case-insensitive
+  // and tolerant of leading/trailing whitespace in user input.
+  const normalizedQuery = sidebarSearchQuery.trim().toLowerCase()
   const filteredAgents = agents.filter((agent) =>
-    agent.name.toLowerCase().includes(sidebarSearchQuery.toLowerCase()) ||
-    agent.category.toLowerCase().includes(sidebarSearchQuery.toLowerCase())
+    agent.name.toLowerCase().includes(normalizedQuery) ||
+    agent.category.toLowerCase().includes(normalizedQuery)
   )
 
   // Group agents by category
@@ -67,6 +70,7 @@ export default function Sidebar({ open, onClose }) {
             <input
               type="text"
               placeholder="Search agents..."
+              aria-label="Search agents"
               value={sidebarSearchQuery}
               onChange={(e) => setSidebarSearchQuery(e.target.value)}
               className="w-full pl-8 pr-8 py-1.5 text-[12px] rounded-md border transition-all
@@ -75,7 +79,9 @@ export default function Sidebar({ open, onClose }) {
             />
             {sidebarSearchQuery && (
               <button
+                type="button"
                 onClick={() => setSidebarSearchQuery('')}
+                aria-label="Clear search"
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:text-text-muted dark:hover:text-text-primary transition-colors"
               >
                 <Icons.X size={14} />


### PR DESCRIPTION
## Summary

Resolves the remaining acceptance criteria for [#194](https://github.com/AditthyaSS/iloveAgents/issues/194) — *Add Search Functionality to the Agent Sidebar*.

The sidebar already renders a search box, real-time filtering, empty-category hiding, and a clear button. While verifying it against the issue's acceptance criteria I found two gaps, which this PR closes:

1. **Whitespace-tolerant matching.** The issue requires that "matching is case-insensitive and works with leading/trailing spaces in user input." Previously the query was only lowercased, so typing `" seo"` (with a leading space) failed to match `SEO` agents. The query is now normalized with `trim()` + `toLowerCase()` before filtering.
2. **Accessibility.** The clear button and the search input had no accessible name (the button relied on its icon only). Added `aria-label="Clear search"` on the button and `aria-label="Search agents"` on the input — matching the pattern already used by the agents home-page search (`HomePage.jsx`). Also added `type="button"` to the clear button so it can never act as a form submit.

## Changes

- `src/components/Sidebar.jsx`
  - Compute a normalized (`trim` + `toLowerCase`) query once and use it for both the name and category match.
  - Add `aria-label` to the search input and the clear button.
  - Add `type="button"` to the clear button.

## Design notes

- Matching stays case-insensitive and now ignores surrounding whitespace, so a stray space no longer empties the results.
- The search box continues to sit directly below the **Agents** header, outside the scrollable `<nav>`, so it stays pinned at the top of the sidebar while the agent list scrolls. No change to scroll architecture was needed.
- Empty categories remain hidden (categories are derived from the filtered list), and the clear "X" still appears only when the query is non-empty.

## Testing

- `npm run build` — succeeds, no errors (only the pre-existing chunk-size warning).
- Manual checks: typing filters the list in real time; `" seo"` with leading/trailing spaces matches; clearing restores the full list; categories with no matches are not rendered; the "X" appears only when there is a query; keyboard focus reaches the clear button with an announced label.

Closes #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent filter search to handle whitespace and case variations more consistently.

* **Accessibility**
  * Added screen reader labels to the search input and clear search button for better accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->