### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
 
 ---
 
+## 👥 Contributors
+
+Thanks to all contributors ❤️
+
+[![Contributors](https://contrib.rocks/image?repo=aditthyass/iloveagents)](https://github.com/aditthyass/iloveagents/graphs/contributors)
+
+---
+
 ## License
 
 Licensed under the [MIT License](LICENSE) — use it, fork it, build on it.


### PR DESCRIPTION
## What does this PR do?

Adds a Contributors section to the README.md using contrib.rocks. It displays all repository contributors visually and links to the GitHub contributors graph to recognize community contributions.

## Type of change

* [ ] New agent
* [ ] Bug fix
* [ ] UI improvement
* [x] Documentation
* [ ] Other

## Checklist

* [x] I ran `npm run build` locally and it passed ✅
* [x] I tested my changes in the browser ✅
* [x] I did not break any existing agents ✅
* [x] I did not use `import agents from '../agents/registry'` ✅
* [x] My PR has a clear description above ✅


closes #532 