### PR TITLE
fix(theme): improve contrast for sidebar labels in light mode

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -79,7 +79,7 @@ const filteredAgents = !normalizedQuery
 >
   {/* Header */}
   <div className="px-4 py-3 flex items-center justify-between">
-    <span className="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
+    <span className="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-500">
       Agents
     </span>
 
@@ -154,7 +154,7 @@ const filteredAgents = !normalizedQuery
           type="button"
           onClick={() => toggleCategory(category)}
           aria-expanded={isCategoryExpanded}
-          className="w-full flex items-center justify-between gap-2 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest dark:text-text-muted text-gray-400 hover:text-accent transition-colors"
+          className="w-full flex items-center justify-between gap-2 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest dark:text-text-muted text-gray-500 hover:text-accent transition-colors"
         >
           <span className="flex items-center gap-1.5 min-w-0">
             <span className="truncate">{category}</span>
@@ -202,7 +202,7 @@ const filteredAgents = !normalizedQuery
   })}
 
   {filteredAgents.length === 0 && (
-    <div className="px-4 py-8 text-center text-xs text-gray-400 dark:text-text-muted">
+    <div className="px-4 py-8 text-center text-xs text-gray-500 dark:text-text-muted">
       No agents found
     </div>
   )}
@@ -215,7 +215,7 @@ const filteredAgents = !normalizedQuery
               href="https://github.com/AditthyaSS/iloveAgents"
               target="_blank"
               rel="noopener noreferrer"
-              className="block text-[11px] dark:text-text-muted text-gray-400 hover:text-accent transition-colors"
+              className="block text-[11px] dark:text-text-muted text-gray-500 hover:text-accent transition-colors"
             >
               GitHub →
             </a>
@@ -224,12 +224,12 @@ const filteredAgents = !normalizedQuery
               href="https://github.com/AditthyaSS/iloveAgents/issues"
               target="_blank"
               rel="noopener noreferrer"
-              className="block text-[11px] dark:text-text-muted text-gray-400 hover:text-accent transition-colors"
+              className="block text-[11px] dark:text-text-muted text-gray-500 hover:text-accent transition-colors"
             >
               Contribute →
             </a>
 
-            <span className="block text-[10px] dark:text-text-muted/60 text-gray-300">
+            <span className="block text-[10px] dark:text-text-muted/60 text-gray-400">
               GSSoC 2026
             </span>
           </div>


### PR DESCRIPTION
## What does this PR do?
Fixes a low-contrast accessibility gap found in the Agent Sidebar when using light theme. Category labels (HR, Data Science, Sales, etc.), section headers, and footer links (GitHub, Contribute) were using `text-gray-400` on a white background, producing a contrast ratio below WCAG AA standards and making the text appear washed out and hard to read. Bumped these to `text-gray-500` to meet the 4.5:1 minimum contrast ratio while keeping dark mode styling untouched.

## Type of change
- [ ] New agent
- [x] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots 
**Before:** Category labels and footer links appear washed out / low-contrast in light mode (see attached screenshot from sidebar).

<img width="932" height="932" alt="image" src="https://github.com/user-attachments/assets/7ec5c229-1d6a-4f9f-8445-a68ab07ba942" />

**After:** Same elements now meet WCAG AA contrast requirements while remaining visually consistent with the existing design language.

<img width="917" height="922" alt="image" src="https://github.com/user-attachments/assets/824dbe27-509d-4788-8784-8caac9365f34" />
Closes #534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling for sidebar text elements, including the Agents header, category toggle buttons, empty state message, GitHub footer link, and Contribute/GSSoC footer section for improved consistency and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->