### PR TITLE
feat: add loading skeletons for agent cards during data fetch - shows…

### DIFF
--- a/src/components/AgentCardSkeleton.jsx
+++ b/src/components/AgentCardSkeleton.jsx
@@ -1,0 +1,33 @@
+/**
+ * AgentCardSkeleton — placeholder UI shown while agent data is being
+ * lazily loaded via loadAllAgents(). Mirrors AgentCard's dimensions
+ * to prevent layout shift once real data arrives.
+ */
+export default function AgentCardSkeleton() {
+  return (
+    <div
+      className="rounded-lg border p-4 bg-white border-gray-200
+      dark:bg-surface-card dark:border-border animate-pulse"
+      aria-hidden="true"
+    >
+      {/* Top row: icon + badges */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="w-10 h-10 rounded-lg bg-gray-200 dark:bg-surface-input" />
+        <div className="flex items-center gap-1.5">
+          <div className="h-4 w-12 rounded-full bg-gray-200 dark:bg-surface-input" />
+        </div>
+      </div>
+
+      {/* Name + description */}
+      <div className="h-4 w-3/4 rounded bg-gray-200 dark:bg-surface-input mb-2" />
+      <div className="h-3 w-full rounded bg-gray-200 dark:bg-surface-input mb-1.5" />
+      <div className="h-3 w-5/6 rounded bg-gray-200 dark:bg-surface-input mb-3" />
+
+      {/* Bottom: provider badge */}
+      <div className="flex items-center justify-between mt-auto">
+        <div className="h-4 w-16 rounded-full bg-gray-200 dark:bg-surface-input" />
+        <div className="h-3 w-10 rounded bg-gray-200 dark:bg-surface-input" />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Bot, Users, Code2, ArrowRight, Github, Search, X, SlidersHorizontal, Star, Heart, Swords, GitBranch, ChevronDown } from 'lucide-react'
 import { loadAllAgents } from '../agents/registry'
+import AgentCardSkeleton from '../components/AgentCardSkeleton'
 import AgentCard from '../components/AgentCard'
 import { useFavorites } from '../lib/useFavorites'
 import { useHistory } from '../lib/useHistory'
@@ -30,9 +31,10 @@ export default function HomePage() {
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState('')
   const [agents, setAgents] = useState([])
+  const [agentsLoading, setAgentsLoading] = useState(true)
 
 useEffect(() => {
-  loadAllAgents().then(setAgents)
+  loadAllAgents().then(setAgents).finally(() => setAgentsLoading(false))
 }, [])
   const [selectedCategory, setSelectedCategory] = useState(null)
   const allCategories = useMemo(() => {
@@ -467,7 +469,13 @@ useEffect(() => {
             </span>
           </div>
 
-          {filteredAgents.length > 0 ? (
+          {agentsLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+              {Array.from({ length: 9 }).map((_, idx) => (
+                <AgentCardSkeleton key={idx} />
+              ))}
+            </div>
+          ) : filteredAgents.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-3">
               {filteredAgents.map((agent, idx) => (
                 <div


### PR DESCRIPTION
… 9 pulsing skeleton cards while loadAllAgents lazy-loads definitions, preventing blank screen flash and reducing perceived load time. Closes #529

## What does this PR do?
Adds loading skeleton placeholders for the agent cards grid on the HomePage. Since `loadAllAgents()` lazy-loads 100+ agent definition files via dynamic imports, there was previously a blank screen flash while data fetched, especially noticeable on slower connections. Added an `agentsLoading` state tied to the existing fetch promise, and a new `AgentCardSkeleton` component that mirrors the real `AgentCard` dimensions (icon, badge, title, description, provider tag) with a pulse animation, preventing layout shift once real data arrives.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots 
Tested using Chrome DevTools network throttling (Slow 3G) to simulate the loading window — 9 pulsing skeleton cards display in the same grid layout as real agent cards, then smoothly replaced once `loadAllAgents()` resolves. No layout shift observed.
<img width="682" height="680" alt="image" src="https://github.com/user-attachments/assets/de18e516-d73b-43d9-931c-08171c50d333" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading state with skeleton placeholder cards that display while fetching agent information, providing clearer visual feedback during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->