### PR TITLE
fix: differentiate sidebar and menu icons for mobile clarity - replac…

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -8,6 +8,8 @@ import {
   X,
   HelpCircle,
   Sparkles,
+  PanelLeftOpen,
+  PanelLeftClose,
   PanelsTopLeft,
   Workflow,
   LibraryBig
@@ -98,7 +100,7 @@ export default function Navbar({ sidebarOpen, setSidebarOpen }) {
             "
             aria-label="Toggle sidebar"
           >
-            {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
+            {sidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
           </button>
 
           <Link


### PR DESCRIPTION
…ed duplicate hamburger icon on sidebar toggle with panel icon to avoid confusion with the separate mobile nav menu button. Verified no horizontal overflow on HomePage, AgentRunner, WorkflowBuilder, and Suites pages at 375px and 390px widths. Closes #535

## What does this PR do?
Conducted a full mobile responsiveness audit of the Agent Discovery interface (HomePage), Agent Runner, Workflow Builder, and Suites pages at 375px and 390px widths. Confirmed no horizontal overflow, properly wrapping cards, readable typography, and adequately sized touch targets across all four pages. Found and fixed one real usability issue: the sidebar toggle and mobile nav menu both used an identical hamburger icon, making it look like a duplicate/broken button. Replaced the sidebar toggle icon with a distinct panel icon (PanelLeftOpen/PanelLeftClose) so each control is visually distinguishable.

## Type of change
- [ ] New agent
- [x] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
Tested at 375px (iPhone SE) viewport across HomePage, Agent Runner, Workflow Builder, and Suites — no overflow found on any page. Before: both sidebar toggle and nav menu showed identical hamburger icons. After: sidebar toggle now shows a distinct panel icon, nav menu retains the hamburger icon.

<img width="410" height="848" alt="Screenshot 2026-06-18 103639" src="https://github.com/user-attachments/assets/de4b3344-5801-42b3-a40d-c18a7c4f40da" />


Closes #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the sidebar toggle button icon so it clearly reflects the current state: showing a “close” icon when the sidebar is open and an “open” icon when it’s closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->