### PR TITLE
feat: add Medical Research Summarizer agent

### DIFF
--- a/src/agents/definitions/medical-research-summarizer.js
+++ b/src/agents/definitions/medical-research-summarizer.js
@@ -52,6 +52,6 @@ Rules:
 - Base the summary strictly on the provided text. Never invent results, statistics, or conclusions that aren't in the source.
 - If only an abstract was provided (not full text), say so explicitly and note that methodology/limitations detail is necessarily limited.
 - Keep the tone neutral, evidence-based, and free of hype — do not overstate clinical significance or certainty.
-- End every summary with this exact note on its own line: "_This is an informational summary, not medical advice. Please discuss any findings relevant to your own care with a qualified healthcare provider._"`,
+- End every summary with this exact note on its own line: _This is an informational summary, not medical advice. Please discuss any findings relevant to your own care with a qualified healthcare provider._`,
   outputType: 'markdown',
 }

--- a/src/agents/definitions/medical-research-summarizer.js
+++ b/src/agents/definitions/medical-research-summarizer.js
@@ -1,81 +1,57 @@
-const medicalResearchSummarizer = {
+export default {
   id: 'medical-research-summarizer',
   name: 'Medical Research Summarizer',
   description:
-    'Summarizes medical research papers and abstracts into plain English with key findings, methodology, limitations, and clinical implications.',
-  category: 'Research',
-  icon: 'HeartPulse',
-  provider: 'any',
+    'Turns a dense medical research abstract or full paper into a plain-English summary with key findings, methodology, limitations, and practical takeaways.',
+  category: 'Healthcare',
+  icon: 'Stethoscope',
+  provider: 'any', // 'openai' | 'anthropic' | 'gemini' | 'any'
   defaultProvider: 'openai',
   model: 'gpt-4o',
-
   inputs: [
     {
-      id: 'researchText',
-      label: 'Medical Research Paper or Abstract',
+      id: 'paper_text',
+      label: 'Research Paper (Abstract or Full Text)',
       type: 'textarea',
       placeholder:
-        'Paste a medical research abstract or full research paper here...',
+        'Paste the abstract, full text, or key sections (intro, methods, results, discussion) of the medical research paper here...',
       required: true,
     },
     {
-      id: 'targetAudience',
-      label: 'Target Audience',
+      id: 'audience',
+      label: 'Summarize For',
       type: 'select',
-      options: [
-        'General Public',
-        'Patients',
-        'Healthcare Professionals',
-        'Researchers',
-      ],
-      defaultValue: 'General Public',
-      required: true,
+      options: ['Patient', 'Healthcare Practitioner', 'Both'],
+      placeholder: 'Choose who this summary is for',
+      required: false,
     },
   ],
+  systemPrompt: `You are a medical research communicator. Your job is to help healthcare professionals and patients quickly understand dense medical research papers without losing accuracy.
 
-  systemPrompt: `You are an expert Medical Research Summarizer.
+You will be given a research abstract or full text, and optionally a target audience (Patient, Healthcare Practitioner, or Both). Produce a clear, accurate, plain-English summary using exactly this Markdown structure:
 
-Your task is to analyze medical research papers, journal articles, clinical studies, and abstracts and explain them in simple, accurate language.
+## Plain English Summary
+2-4 sentences explaining what the study is about and what it found, in everyday language a non-specialist could follow.
 
-Generate your response using the following format:
+## Key Findings
+3-6 bullet points stating only what the paper actually found. Include key numbers, effect sizes, or statistical significance where reported, explained in plain terms (e.g. "patients were twice as likely to..." rather than just raw stats).
 
-# Plain English Summary
-Provide a concise summary understandable by the selected audience.
+## Methodology
+A short paragraph or 3-5 bullets covering: study design (e.g. randomized controlled trial, observational, meta-analysis), sample size and population, what was measured, and any comparison/control group. Use precise medical terminology here, but briefly define any jargon.
 
-# Key Findings
-- List the most important findings.
-- Highlight statistically or clinically significant outcomes.
+## Limitations
+3-5 bullets on limitations, biases, or caveats. Prioritize limitations the authors themselves note. If the source text doesn't state limitations explicitly, you may add reasonable methodological caveats (e.g. small sample size, short follow-up, lack of diversity) but clearly label these as "Not stated by the authors, but worth noting:".
 
-# Methodology
-Explain:
-- Study design
-- Number of participants (if available)
-- Data collection methods
-- Analysis approach
+## What This Means
+- **For Patients:** A plain, reassuring, non-alarming explanation of practical relevance — what this could mean for someone navigating a related health situation, and what questions it might be worth asking a doctor.
+- **For Practitioners:** Clinical implications — whether this is confirmatory or preliminary evidence, which patient population it applies to, and anything that should temper how it's applied in practice.
 
-# Limitations
-Discuss:
-- Potential weaknesses
-- Sample size limitations
-- Biases
-- Missing information
+If an audience preference was provided, give that section more depth and trim the other one to 1-2 sentences. If no preference was given, give both sections similar depth.
 
-# Implications
-Explain what the findings may mean for:
-- Patients
-- Healthcare professionals
-- Future research
-
-Guidelines:
-- Do not exaggerate conclusions.
-- Clearly distinguish evidence from speculation.
-- Use plain English whenever possible.
-- Maintain scientific accuracy.
-- Be objective and unbiased.
-- Format the response in clean Markdown.
-`,
-
+Rules:
+- Base the summary strictly on the provided text. Never invent results, statistics, or conclusions that aren't in the source.
+- If only an abstract was provided (not full text), say so explicitly and note that methodology/limitations detail is necessarily limited.
+- Keep the tone neutral, evidence-based, and free of hype — do not overstate clinical significance or certainty.
+- End every summary with this exact note on its own line: "_This is an informational summary, not medical advice. Please discuss any findings relevant to your own care with a qualified healthcare provider._"`,
   outputType: 'markdown',
-};
-
-export default medicalResearchSummarizer;
+}


### PR DESCRIPTION
## What this PR does

Adds a new **Medical Research Summarizer** agent to the Healthcare category.

This agent turns dense medical research abstracts or full papers into plain-English summaries with:
- **Plain English Summary** — an accessible overview of the study
- **Key Findings** — bullet-pointed results with effect sizes explained in plain terms
- **Methodology** — study design, sample size, and measurement approach
- **Limitations** — author-stated and inferred caveats
- **What This Means** — separate practical takeaways for patients and practitioners

### Implementation details
- Single config file: \src/agents/definitions/medical-research-summarizer.js\
- Uses the existing \Healthcare\ category — no changes to \categories.js\
- Auto-registered via \import.meta.glob\ in \egistry.js\ — no registry edits needed
- Icon: \Stethoscope\ from lucide-react
- Inputs: textarea (paper text) + select dropdown (audience: Patient / Healthcare Practitioner / Both)

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Added targeted audience options for the medical research summarizer: Patient, Healthcare Practitioner, or Both
  * Improved Markdown output formatting with a stricter, consistent structure and required ending disclaimer line
  * Refined how abstracts vs full papers are summarized, including audience-dependent section depth
  * Updated input naming to use `paper_text` and made the audience selection optional
<!-- end of auto-generated comment: release notes by coderabbit.ai -->