### PR TITLE
Workflow Card — Smooth Transition and Card Hover — Gradient Overlay (Clean Revert)

### DIFF
--- a/src/pages/WorkflowLibrary.jsx
+++ b/src/pages/WorkflowLibrary.jsx
@@ -62,10 +62,17 @@ function WorkflowCard({ workflow, onRun, onView, onFork }) {
 
   return (
     <div
-      className="rounded-lg border p-4 transition-all duration-200
-        dark:bg-surface-card dark:border-border dark:hover:border-accent/40
-        bg-white border-gray-200 hover:border-indigo-300 hover:shadow-lg hover:shadow-accent/5"
+      className="group relative rounded-lg border p-4 transition-all duration-300 overflow-hidden
+        dark:bg-surface-card dark:border-border
+        bg-white border-gray-200
+        hover:border-indigo-300/60 dark:hover:border-indigo-500/40
+        hover:shadow-xl hover:shadow-indigo-500/10 dark:hover:shadow-indigo-500/15
+        hover:-translate-y-0.5"
     >
+      {/* Hover gradient overlay — signature cyan→indigo→rose theme */}
+      <div className="pointer-events-none absolute inset-0 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300
+        bg-gradient-to-br from-cyan-400/8 via-indigo-400/8 to-rose-400/8
+        dark:from-cyan-500/10 dark:via-indigo-500/10 dark:to-rose-500/10" />
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
@@ -226,9 +233,14 @@ export default function WorkflowLibrary() {
       </div>
 
       {/* Search */}
-      <div className="relative max-w-md mb-6">
-        <div className="absolute inset-y-0 left-0 pl-3.5 flex items-center pointer-events-none">
-          <Search size={14} className="dark:text-text-muted text-gray-400" />
+      <div className="relative max-w-md mb-6 group">
+        {/* Gradient glow ring — matches navbar/sidebar theme */}
+        <div className="pointer-events-none absolute -inset-[1.5px] rounded-full opacity-0 group-focus-within:opacity-100 transition-opacity duration-300
+          bg-gradient-to-r from-cyan-400/60 via-indigo-400/60 to-rose-400/60
+          dark:from-cyan-500/50 dark:via-indigo-500/50 dark:to-rose-500/50 blur-[2px]" />
+
+        <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none z-10">
+          <Search size={14} className="dark:text-text-muted text-gray-400 group-focus-within:text-accent transition-colors duration-200" />
         </div>
         <input
           id="workflow-search"
@@ -236,16 +248,19 @@ export default function WorkflowLibrary() {
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search workflows..."
-          className="w-full pl-9 pr-9 py-2 rounded-lg border text-sm transition-all
-            dark:bg-surface-card dark:border-border dark:text-text-primary dark:placeholder-text-muted
-            bg-white border-gray-200 text-gray-900 placeholder-gray-400
-            focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50"
+          className="relative w-full pl-10 pr-10 py-2.5 rounded-full border text-sm transition-all duration-300
+            dark:bg-[#101014]/80 dark:border-white/10 dark:text-text-primary dark:placeholder-text-muted
+            bg-white/80 border-white/60 text-gray-900 placeholder-gray-400
+            backdrop-blur-md
+            shadow-[0_4px_20px_rgba(99,102,241,0.08)] dark:shadow-[0_4px_20px_rgba(99,102,241,0.12)]
+            focus:outline-none focus:shadow-[0_6px_28px_rgba(99,102,241,0.18)] dark:focus:shadow-[0_6px_28px_rgba(99,102,241,0.22)]
+            focus:border-indigo-300/60 dark:focus:border-indigo-500/40"
         />
         {searchQuery && (
           <button
             onClick={() => setSearchQuery('')}
-            className="absolute inset-y-0 right-0 pr-3 flex items-center
-              dark:text-text-muted text-gray-400 hover:text-accent transition-colors"
+            className="absolute inset-y-0 right-0 pr-4 flex items-center z-10
+              dark:text-text-muted text-gray-400 hover:text-accent transition-colors duration-200"
           >
             <X size={14} />
           </button>


### PR DESCRIPTION
##closes #562

✅ 2. Workflow Card — Smooth Transition
Changed transition-all duration-200 → transition-all duration-300 for a smoother feel
Added group, relative, and overflow-hidden for the overlay technique
Adds a subtle lift effect (hover:-translate-y-0.5) with a deeper shadow on hover
✅ 3. Card Hover — Gradient Overlay (Clean Revert)
An absolutely-positioned overlay <div> sits inside the card at opacity-0
On hover (group-hover:), it fades to opacity-100 — showing the signature cyan→indigo→rose gradient (matching the navbar's from-cyan-400/30 via-indigo-400/30 to-rose-400/30)
On mouse-leave, it cleanly reverts via transition-opacity duration-300 with no flash
pointer-events-none ensures the overlay never blocks clicks on card buttons

## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [x] Documentation
- [x] Other


## under gssoc26


## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced workflow card visual styling with updated animations and interactive hover effects
  * Refined search bar design with gradient glow effect and improved input field styling
  * Improved search interaction feedback with updated icon and clear button styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->