### PR TITLE
fix: resolve ReferenceError crash when forking workflows

### DIFF
--- a/src/pages/WorkflowBuilder.jsx
+++ b/src/pages/WorkflowBuilder.jsx
@@ -52,20 +52,17 @@ export default function WorkflowBuilder() {
     }
   }, [agents, location.state?.preselectedAgents, hasResolvedPreselected])
 
-  // Pre-select agent if coming from AgentRunner
+  // Pre-populate fields if forking an existing workflow
   useEffect(() => {
-  if (forkedWorkflow) {
-    setNodes(
-      JSON.parse(JSON.stringify(forkedWorkflow.nodes || []))
-    )
-
-    setEdges(
-      JSON.parse(JSON.stringify(forkedWorkflow.edges || []))
-    )
-
-    setTitle(`Copy of ${forkedWorkflow.title}`)
-  }
-}, [forkedWorkflow])
+    if (forkedWorkflow && agents.length > 0) {
+      setTitle(`Copy of ${forkedWorkflow.title}`)
+      setDescription(forkedWorkflow.description || '')
+      const loaded = (forkedWorkflow.agents || [])
+        .map((id) => agents.find((a) => a.id === id))
+        .filter(Boolean)
+      setSelectedAgents(loaded)
+    }
+  }, [forkedWorkflow, agents])
 
   // Agents already in the chain — prevent duplicates
   const selectedIds = new Set(selectedAgents.map((a) => a.id))


### PR DESCRIPTION
## What does this PR do?
Fixes a crash that occurs when attempting to fork or copy an existing workflow from the Workflow Library. 

The `WorkflowBuilder` component was referencing obsolete `setNodes` and `setEdges` state setters in its `useEffect` hook when receiving a `forkedWorkflow` in `location.state`. This threw a `ReferenceError: setNodes is not defined` and crashed the React application. 

This PR resolves the issue by replacing the legacy calls with the correct state initialization logic, mapping the forked workflow's agent IDs to the loaded registry definitions, and setting the title and description states properly.
Fixes #567 

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
*Not applicable (functional bug fix).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workflow forking initialization to ensure proper loading of agent data and workflow details in the correct sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->