### PR TITLE
[Bug]: Wrapped ErrorBoundary to show Error page instead of blank screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import WorkflowDetail from './pages/WorkflowDetail'
 import WorkflowRunner from './pages/WorkflowRunner'
 import NotFoundPage from './pages/NotFoundPage'
 import SuitesPage from './pages/SuitesPage'
+import ErrorBoundary from './components/ErrorBoundary'
 
 // Shared layout: Navbar + Sidebar + main content area
 function MainLayout({ sidebarOpen, setSidebarOpen }) {
@@ -41,27 +42,29 @@ export default function App() {
     <div className="min-h-screen transition-theme dark:bg-surface bg-gray-50">
       <ScrollToTop />
       <ScrollToBottom />
-      <Routes>
-        {/* Battle Mode — full-screen, own layout */}
-        <Route path="/battle" element={<BattleModeLanding />} />
-        <Route path="/battle/setup" element={<BattleModeSetup />} />
-        <Route path="/battle/arena" element={<BattleModeArena />} />
-        <Route path="/battle/winner" element={<BattleModeWinner />} />
+      <ErrorBoundary>
+        <Routes>
+          {/* Battle Mode — full-screen, own layout */}
+          <Route path="/battle" element={<BattleModeLanding />} />
+          <Route path="/battle/setup" element={<BattleModeSetup />} />
+          <Route path="/battle/arena" element={<BattleModeArena />} />
+          <Route path="/battle/winner" element={<BattleModeWinner />} />
 
-        {/* Main app layout — all routes share Navbar + Sidebar */}
-        <Route element={<MainLayout sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />}>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/agent/:id" element={<AgentPage />} />
-          {/* Suites */}
-          <Route path="/suites" element={<SuitesPage />} />
-          {/* Workflow routes */}
-          <Route path="/workflows" element={<WorkflowLibrary />} />
-          <Route path="/workflows/build" element={<WorkflowBuilder />} />
-          <Route path="/workflows/:id" element={<WorkflowDetail />} />
-          <Route path="/workflows/:id/run" element={<WorkflowRunner />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Route>
-      </Routes>
+          {/* Main app layout — all routes share Navbar + Sidebar */}
+          <Route element={<MainLayout sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />}>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/agent/:id" element={<AgentPage />} />
+            {/* Suites */}
+            <Route path="/suites" element={<SuitesPage />} />
+            {/* Workflow routes */}
+            <Route path="/workflows" element={<WorkflowLibrary />} />
+            <Route path="/workflows/build" element={<WorkflowBuilder />} />
+            <Route path="/workflows/:id" element={<WorkflowDetail />} />
+            <Route path="/workflows/:id/run" element={<WorkflowRunner />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Routes>
+      </ErrorBoundary>
     </div>
   )
 }


### PR DESCRIPTION
## What does this PR do?
Wrapped the `ErrorBoundary` component around the Routes in App.jsx so that in **any** page, an error occurs, the ErrorBoundary component renders as expected instead of a blank black screen.

## Type of change
- [x] Bug fix

Closes #570 

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
<img width="848" height="704" alt="image" src="https://github.com/user-attachments/assets/4e4667b6-22f9-41f9-a5e9-c8eb6d6ec654" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented centralized error handling for application routing to provide graceful error management and improved stability during page navigation and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->