### PR TITLE
feat: add Syllabus-to-Project Planner agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1415,6 +1416,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1597,6 +1599,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2357,6 +2360,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3501,6 +3505,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3689,6 +3694,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3701,6 +3707,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4310,6 +4317,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4522,6 +4530,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4615,6 +4624,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1416,7 +1415,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1599,7 +1597,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2360,7 +2357,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3505,7 +3501,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3694,7 +3689,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3707,7 +3701,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4317,7 +4310,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4530,7 +4522,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4624,7 +4615,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/agents/definitions/syllabus-to-project-planner.js
+++ b/src/agents/definitions/syllabus-to-project-planner.js
@@ -23,10 +23,14 @@ const syllabusToProjectPlanner = {
     ],
     systemPrompt: `You are an expert technical curriculum designer and senior software engineer. A user will provide an academic syllabus topic and optionally a preferred tech stack. 
 
-Your goal is to convert this theoretical topic into exactly 3 practical, resume-worthy coding project ideas ranging from beginner to advanced.
+Your goal is to convert this theoretical topic into exactly 3 practical, resume-worthy coding project ideas:
+- 1 Beginner project
+- 1 Intermediate project
+- 1 Advanced project
 
 Academic Subject: {{academic_subject}}
 Target Tech Stack: {{tech_stack}}
+If Target Tech Stack is empty, choose a practical, industry-standard stack suitable for the subject.
 
 For EACH of the 3 projects, format your response strictly with the following subheadings:
 

--- a/src/agents/definitions/syllabus-to-project-planner.js
+++ b/src/agents/definitions/syllabus-to-project-planner.js
@@ -1,0 +1,43 @@
+const syllabusToProjectPlanner = {
+    id: 'syllabus-to-project-planner',
+    name: 'Syllabus-to-Project Planner',
+    description: 'Turns dry, academic syllabus topics or engineering course chapters into highly practical, resume-worthy coding project ideas.',
+    category: 'Education',
+    icon: 'GraduationCap',
+    provider: 'gemini',
+    inputs: [
+        {
+            id: 'academic_subject',
+            label: 'The academic subject or topic name',
+            type: 'text',
+            placeholder: 'e.g., Data Structures: Binary Search Trees or Operating Systems',
+            required: true,
+        },
+        {
+            id: 'tech_stack',
+            label: 'Target tech stack or programming language preferred (optional)',
+            type: 'text',
+            placeholder: 'e.g., Python, React & Node.js, or C++',
+            required: false,
+        }
+    ],
+    systemPrompt: `You are an expert technical curriculum designer and senior software engineer. A user will provide an academic syllabus topic and optionally a preferred tech stack. 
+
+Your goal is to convert this theoretical topic into exactly 3 practical, resume-worthy coding project ideas ranging from beginner to advanced.
+
+Academic Subject: {{academic_subject}}
+Target Tech Stack: {{tech_stack}}
+
+For EACH of the 3 projects, format your response strictly with the following subheadings:
+
+### [Project Name] (Difficulty Level)
+
+**Core Architecture:** [Provide exactly a brief 2-sentence breakdown of how the project components should interact.]
+
+**Learning Outcomes:** [List 2-3 bullet points detailing what real-world skills this project proves on a resume.]
+
+Ensure the output is clean, highly practical, and strictly follows this format.`,
+    outputType: 'markdown',
+};
+
+export default syllabusToProjectPlanner;


### PR DESCRIPTION
Closes #428

## What does this PR do?
This PR adds the "Syllabus-to-Project Planner" agent to the Education category. It uses the Google Gemini provider to take a theoretical academic subject and an optional tech stack, and converts them into 3 practical, resume-worthy coding projects (Beginner to Advanced). The output is strictly formatted in markdown with a 2-sentence core architecture and 2-3 learning outcome bullet points per project.

## Type of change
- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
<img width="1712" height="797" alt="Screenshot 2026-06-21 112957" src="https://github.com/user-attachments/assets/b985b141-c33e-4f9a-ac11-c959ce80da31" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new AI agent that transforms academic syllabi into project planning suggestions. The agent accepts an academic subject and optional technology stack to generate three beginner-to-advanced project ideas formatted in markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->