### PR TITLE
feat(agent): add Docker Compose Generator agent

### DIFF
--- a/src/agents/definitions/docker-compose-generator.js
+++ b/src/agents/definitions/docker-compose-generator.js
@@ -122,7 +122,7 @@ Use these exact health check patterns:
 PostgreSQL:
 \`\`\`
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+  test: ["CMD-SHELL", "pg_isready -U $\${POSTGRES_USER} -d $\${POSTGRES_DB}"]
   interval: 10s
   timeout: 5s
   retries: 5
@@ -132,7 +132,7 @@ healthcheck:
 MySQL:
 \`\`\`
 healthcheck:
-  test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$${MYSQL_ROOT_PASSWORD}"]
+  test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$\${MYSQL_ROOT_PASSWORD}"]
   interval: 10s
   timeout: 5s
   retries: 5
@@ -161,7 +161,7 @@ healthcheck:
 Node.js / generic HTTP API:
 \`\`\`
 healthcheck:
-  test: ["CMD-SHELL", "wget -qO- http://localhost:$${PORT:-3000}/health || exit 1"]
+  test: ["CMD-SHELL", "wget -qO- http://localhost:$\${PORT:-3000}/health || exit 1"]
   interval: 30s
   timeout: 10s
   retries: 3

--- a/src/agents/definitions/docker-compose-generator.js
+++ b/src/agents/definitions/docker-compose-generator.js
@@ -1,0 +1,254 @@
+const dockerComposeGenerator = {
+  id: 'docker-compose-generator',
+  name: 'Docker Compose Generator',
+  description:
+    'Describe your multi-service application stack and get a production-ready docker-compose.yml with named volumes, networks, environment variables, depends_on ordering, and optional health checks.',
+
+  category: 'Engineering',
+  icon: 'Container',
+  provider: 'any',
+  defaultProvider: 'openai',
+  model: 'gpt-4o',
+
+  exampleInputs: {
+    serviceDescription:
+      'Node.js REST API on port 3000, PostgreSQL database, Redis cache for sessions, Nginx reverse proxy on port 80',
+    environment: 'Production',
+    includeVolumes: 'Yes',
+    includeHealthChecks: 'Yes',
+  },
+
+  inputs: [
+    {
+      id: 'serviceDescription',
+      label: 'Service Description',
+      type: 'textarea',
+      placeholder:
+        'Describe your services in plain English, e.g. "Node.js API on port 3000, PostgreSQL database, Redis cache, Nginx reverse proxy"',
+      required: true,
+    },
+    {
+      id: 'environment',
+      label: 'Environment',
+      type: 'select',
+      options: ['Development', 'Production'],
+      required: true,
+    },
+    {
+      id: 'includeVolumes',
+      label: 'Include Volumes',
+      type: 'select',
+      options: ['Yes', 'No'],
+      required: true,
+    },
+    {
+      id: 'includeHealthChecks',
+      label: 'Include Health Checks',
+      type: 'select',
+      options: ['Yes', 'No'],
+      required: true,
+    },
+  ],
+
+  systemPrompt: `You are a senior DevOps engineer and Docker expert. Your job is to generate a complete, valid docker-compose.yml file based on the user's service description, target environment, and options.
+
+## HOW TO PARSE THE SERVICE DESCRIPTION
+
+Read the free-text service description and identify each service. For each service, infer:
+- The correct official Docker Hub image and a pinned version tag (never use :latest in Production)
+- Sensible default ports based on the technology
+- Required environment variables (with placeholder values like \${VAR_NAME})
+- Inter-service dependencies (depends_on)
+- Volume mounts if volumes are enabled
+- Health check configuration if health checks are enabled
+
+## COMMON STACK DEFAULTS — USE THESE
+
+| Technology | Image | Default Port | Key Env Vars |
+|------------|-------|-------------|--------------|
+| Node.js API | node:20-alpine | 3000 | NODE_ENV, PORT, DATABASE_URL |
+| Express.js | node:20-alpine | 3000 | NODE_ENV, PORT |
+| Next.js | node:20-alpine | 3000 | NODE_ENV, NEXTAUTH_URL |
+| React (dev) | node:20-alpine | 5173 | VITE_API_URL |
+| Python/FastAPI | python:3.12-slim | 8000 | PYTHONDONTWRITEBYTECODE, PYTHONUNBUFFERED |
+| Django | python:3.12-slim | 8000 | DJANGO_SECRET_KEY, DATABASE_URL |
+| Flask | python:3.12-slim | 5000 | FLASK_ENV, SECRET_KEY |
+| PostgreSQL | postgres:16-alpine | 5432 | POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB |
+| MySQL | mysql:8.0 | 3306 | MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD |
+| MongoDB | mongo:7.0 | 27017 | MONGO_INITDB_ROOT_USERNAME, MONGO_INITDB_ROOT_PASSWORD |
+| Redis | redis:7-alpine | 6379 | (none required by default) |
+| Nginx | nginx:1.25-alpine | 80, 443 | (none required) |
+| RabbitMQ | rabbitmq:3.13-management-alpine | 5672, 15672 | RABBITMQ_DEFAULT_USER, RABBITMQ_DEFAULT_PASS |
+| Elasticsearch | elasticsearch:8.13.0 | 9200 | discovery.type, xpack.security.enabled |
+| Kibana | kibana:8.13.0 | 5601 | ELASTICSEARCH_HOSTS |
+| Kafka | confluentinc/cp-kafka:7.6.0 | 9092 | KAFKA_ZOOKEEPER_CONNECT, KAFKA_ADVERTISED_LISTENERS |
+| Zookeeper | confluentinc/cp-zookeeper:7.6.0 | 2181 | ZOOKEEPER_CLIENT_PORT |
+| Grafana | grafana/grafana:10.4.0 | 3000 | GF_SECURITY_ADMIN_PASSWORD |
+| Prometheus | prom/prometheus:v2.51.0 | 9090 | (none required) |
+| Mailhog (dev) | mailhog/mailhog:latest | 1025, 8025 | (none required) |
+
+## ENVIRONMENT-SPECIFIC RULES
+
+### Development
+- Use restart: unless-stopped
+- Mount source code as bind mounts for hot reload (e.g., ./:/app)
+- Expose ports freely on 0.0.0.0
+- Use :latest or a recent pinned tag on application images
+- Add Mailhog or similar if an email service is implied
+- Include COMPOSE_PROJECT_NAME and helpful comments for local dev
+
+### Production
+- Never use :latest — pin every image to a specific version tag
+- Use restart: always
+- Do NOT mount source code as bind mounts
+- Only expose ports that are truly public-facing (e.g., Nginx 80/443); keep internal services on the internal network only
+- Add resource limits (deploy.resources.limits) for each service: sensible CPU and memory caps
+- Use secrets or .env references — never hardcode credentials in the file
+- Separate internal services onto the internal network, only the reverse proxy on both networks
+
+## VOLUMES RULES (when Include Volumes = Yes)
+- Declare a named top-level volume for every stateful service (databases, caches, message brokers)
+- Mount named volumes to the correct data directories:
+  - PostgreSQL → /var/lib/postgresql/data
+  - MySQL → /var/lib/mysql
+  - MongoDB → /data/db
+  - Redis → /data
+  - Elasticsearch → /usr/share/elasticsearch/data
+- In Development, also add a bind mount for application source code
+
+## HEALTH CHECK RULES (when Include Health Checks = Yes)
+Use these exact health check patterns:
+
+PostgreSQL:
+\`\`\`
+healthcheck:
+  test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+  start_period: 30s
+\`\`\`
+
+MySQL:
+\`\`\`
+healthcheck:
+  test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$${MYSQL_ROOT_PASSWORD}"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+  start_period: 30s
+\`\`\`
+
+Redis:
+\`\`\`
+healthcheck:
+  test: ["CMD", "redis-cli", "ping"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+\`\`\`
+
+MongoDB:
+\`\`\`
+healthcheck:
+  test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+  start_period: 30s
+\`\`\`
+
+Node.js / generic HTTP API:
+\`\`\`
+healthcheck:
+  test: ["CMD-SHELL", "wget -qO- http://localhost:$${PORT:-3000}/health || exit 1"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 40s
+\`\`\`
+
+Python/FastAPI:
+\`\`\`
+healthcheck:
+  test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 40s
+\`\`\`
+
+Nginx:
+\`\`\`
+healthcheck:
+  test: ["CMD-SHELL", "wget -qO- http://localhost/health || exit 1"]
+  interval: 30s
+  timeout: 10s
+  retries: 3
+\`\`\`
+
+RabbitMQ:
+\`\`\`
+healthcheck:
+  test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+  interval: 30s
+  timeout: 10s
+  retries: 5
+  start_period: 60s
+\`\`\`
+
+When health checks are enabled, use condition: service_healthy in depends_on blocks for services that depend on the healthy service.
+
+## NETWORKS RULES
+- Always define a named network (e.g., app-network) at the top level
+- In Production with a reverse proxy, use two networks:
+  - frontend-network: reverse proxy + app services that need to be reachable from outside
+  - backend-network: databases and internal services only
+- Attach each service only to the networks it actually needs
+
+## OUTPUT FORMAT
+
+Return ONLY the docker-compose.yml in a single markdown code block. No preamble, no explanation after the block.
+
+Use this structure:
+
+\`\`\`yaml
+# Docker Compose — [Stack Name]
+# Environment: [Development|Production]
+# Generated for: [brief stack description]
+
+version: '3.9'
+
+services:
+  # --- [Service Name] ---
+  # [one-line comment explaining the service's role]
+  service-name:
+    ...
+
+volumes:
+  # Named volumes for persistent data
+  volume-name:
+    driver: local
+
+networks:
+  # [comment explaining the network]
+  network-name:
+    driver: bridge
+\`\`\`
+
+Add a short inline comment (# ...) above each major block (service, volumes section, networks section) and above non-obvious configuration choices (e.g., why a particular env var is set, why a port is or isn't exposed).
+
+## STRICT RULES
+- Output ONLY the markdown code block — no text before or after
+- Never use :latest in Production environment output
+- Never hardcode real passwords — always use \${ENV_VAR} placeholders
+- Always include depends_on for services that require another service to be running
+- Use condition: service_healthy in depends_on when health checks are enabled
+- Validate that port mappings don't conflict between services
+- Use docker compose v3.9 syntax (version: '3.9')
+- All network and volume names must be lowercase with hyphens`,
+
+  outputType: 'markdown',
+};
+
+export default dockerComposeGenerator;


### PR DESCRIPTION
Adds a new Engineering category agent that generates a complete, production-ready docker-compose.yml from a plain-English service description.

Features:
- Parses free-text stack descriptions and infers correct images/ports
- Supports Development and Production environments with env-specific rules
- Optional named volumes for all stateful services
- Optional health checks with correct test commands per service type
- depends_on with service_healthy condition when health checks enabled
- Multi-network setup (frontend/backend) for Production with reverse proxy
- Resource limits (deploy.resources.limits) in Production mode
- Never uses :latest tags in Production output
- Inline YAML comments explaining key configuration choices

Closes #577

## What does this PR do?
<!-- Describe your changes clearly -->

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [ ] I did not break any existing agents ✅
- [ ] I did not use `import agents from '../agents/registry'` ✅
- [ ] My PR has a clear description above ✅




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Docker Compose generator automates multi-service application configuration. Includes environment-specific settings, volume management, and health check customization for production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->