### PR TITLE
feat: add run again with different model option

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -31,7 +31,7 @@ import { useApiKey } from "../lib/useApiKey";
 import { streamAgent } from "../lib/llmAdapter";
 import { analyseModels } from "../lib/modelAnalyser";
 import { useHistory } from "../lib/useHistory";
-import { resolveAgentModel, MODEL_MAP } from "../lib/resolveAgentModel";
+import { resolveAgentModel, MODEL_MAP, MODELS, } from "../lib/resolveAgentModel";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 const providerLabels = {
@@ -83,7 +83,7 @@ export default function AgentRunner({ agent }) {
   const [modelRecommendation, setModelRecommendation] = useState(null);
   const [analyserLoading, setAnalyserLoading] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
-
+  const [showModelSwitcher, setShowModelSwitcher] = useState(false);
   const { addJob } = useScheduler();
 
   const isPromptModified = customPrompt !== agent.systemPrompt;
@@ -807,6 +807,50 @@ export default function AgentRunner({ agent }) {
               agentName={agent.name}
               systemPrompt={customPrompt}
             />
+            <div className="flex items-center gap-2 mt-3">
+  <button
+    onClick={() => setShowModelSwitcher(!showModelSwitcher)}
+    className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm
+      bg-accent/10 hover:bg-accent/20 text-accent"
+  >
+    <RotateCw size={14} />
+    Try Different Model
+  </button>
+
+  <span className="text-xs text-gray-500">
+    Current: {selectedModel}
+  </span>
+</div>
+{showModelSwitcher && (
+  <div className="mt-3 p-4 border rounded-lg flex flex-wrap gap-3 items-center">
+<CustomSelect
+      value={provider}
+      onChange={setProvider}
+      options={[
+        { value: "openai", label: "OpenAI" },
+        { value: "anthropic", label: "Anthropic" },
+        { value: "gemini", label: "Gemini" },
+      ]}
+    />
+
+    <CustomSelect
+      value={selectedModel}
+      onChange={setSelectedModel}
+      options={MODELS[provider] || []}
+    />
+
+    <button
+      onClick={async () => {
+        setShowModelSwitcher(false);
+        await handleRun();
+      }}
+      className="px-4 py-2 rounded-lg bg-accent text-white"
+    >
+      Run Again
+    </button>
+
+  </div>
+)}
           </ErrorBoundary>
           <RunRating />
           <div className="flex justify-end">


### PR DESCRIPTION
## What does this PR do?

Adds a **"Try Different Model"** option after agent output is generated.

Closes #582

Previously, users had to scroll back to the top of the page, change the provider/model, and run the agent again to compare outputs. This change introduces a model-switching UI directly below the generated output, allowing users to quickly select another model and rerun the same agent with the existing inputs.

### Changes made

* Added a "Try Different Model" button below agent output.
* Added a model selection dropdown using existing model definitions.
* Reuses the current agent inputs and prompt when rerunning.
* Triggers `handleRun()` with the newly selected model.
* Uses existing model configuration from `resolveAgentModel.js`.

## Type of change

* [x] UI improvement
* [ ] New agent
* [ ] Bug fix
* [ ] Documentation
* [ ] Other

## Checklist

* [x] I ran `npm run build` locally and it passed ✅
* [x] I tested my changes in the browser ✅
* [x] I did not break any existing agents ✅
* [x] I did not use `import agents from '../agents/registry'` ✅
* [x] My PR has a clear description above ✅




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Try Different Model" panel enabling users to switch between different AI model providers (OpenAI, Anthropic, Gemini) and rerun the agent with their newly selected model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->