### PR TITLE
feat: added options parameter with AbortSignal to runAgent in llmAdapter

### DIFF
--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -236,8 +236,9 @@ async function handleErrorResponse(response, provider = "unknown") {
  * @param {string} params.userMessage
  * @returns {Promise<{content: string, tokens: number, duration: number}>}
  */
-export async function runAgent({ provider, model, apiKey, systemPrompt, userMessage }) {
+export async function runAgent({ provider, model, apiKey, systemPrompt, userMessage }, options = {})  {
   const config = PROVIDER_CONFIGS[provider]
+  const { signal } = options;
 
   if (!config) {
     throw new Error(`Unsupported provider: ${provider}`)
@@ -262,6 +263,7 @@ export async function runAgent({ provider, model, apiKey, systemPrompt, userMess
       method: 'POST',
       headers,
       body: JSON.stringify(body),
+      signal,
     })
 
     if (!response.ok) {

--- a/src/lib/llmAdapter.js
+++ b/src/lib/llmAdapter.js
@@ -238,7 +238,7 @@ async function handleErrorResponse(response, provider = "unknown") {
  */
 export async function runAgent({ provider, model, apiKey, systemPrompt, userMessage }, options = {})  {
   const config = PROVIDER_CONFIGS[provider]
-  const { signal } = options;
+  const { signal } = options || {};
 
   if (!config) {
     throw new Error(`Unsupported provider: ${provider}`)


### PR DESCRIPTION
## What does this PR do?
This PR updates the `runAgent` function inside `src/lib/llmAdapter.js` to accept an optional `options` object parameter and safely binds the `signal` property into the core `fetch` API request block. This fully connects and resolves the functional request cancellation capability managed by the `handleStop` AbortController instance inside the `AgentRunner.jsx` component UI.

Closes #594 

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other (Backendless Architecture Enhancement / API Optimization)

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A (No UI changes made. Connected the core AbortSignal logic to the pre-existing Stop button template).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation support for long-running operations by allowing in-flight AI calls to be canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->