### PR TITLE
fix: resolve nested scrollbar conflict on mobile stacked layouts

### DIFF
--- a/src/components/RecentRuns.jsx
+++ b/src/components/RecentRuns.jsx
@@ -65,7 +65,7 @@ const RecentRuns = ({ history, onRerun, onCopy, onDelete, onClearAll }) => {
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto pr-2 -mr-2 space-y-4 custom-scrollbar" style={{ maxHeight: 'calc(100vh - 120px)', minHeight: '300px' }}>
+      <div className="flex-1 overflow-y-auto pr-2 -mr-2 space-y-4 custom-scrollbar max-h-none lg:max-h-[calc(100vh-120px)] min-h-0 lg:min-h-[300px]">
         {history.map((run, idx) => (
           <div
             key={run.id}


### PR DESCRIPTION
## What does this PR do?
Fixes a nested scrollbar conflict that occurs on mobile and tablet viewports when the Recent Runs sidebar stacks vertically at the bottom of the page. 

Currently, the container has a hardcoded inline style `style={{ maxHeight: 'calc(100vh - 120px)', minHeight: '300px' }}` which creates a fixed-height scrollable window inside the webpage. This creates double scrollbars on touch devices (one for the main page and one for the runs container). 

This PR removes the inline style constraint and replaces it with responsive Tailwind classes (`max-h-none lg:max-h-[calc(100vh-120px)] min-h-0 lg:min-h-[300px]`), so it only wraps and scroll-constrains on desktop viewports.
##Fixes #599 

## Type of change
- [ ] New agent
- [x] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

