### PR TITLE
feat: Add Batch Input Mode to run an agent across multiple inputs at once

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -15,6 +15,7 @@ import {
   GitBranch,
   Trash2,
   CalendarClock,
+  Layers,
 } from "lucide-react";
 import ApiKeyBar from "./ApiKeyBar";
 import ApiKeyInfo from "./ApiKeyInfo";
@@ -24,6 +25,7 @@ import CharCounter from "./CharCounter";
 import VoiceInput from "./VoiceInput";
 import SuggestedChainPills from "./SuggestedChainPills";
 import RunRating from "./RunRating";
+import BatchModeRunner from "./BatchModeRunner";
 import ErrorBoundary from "./ErrorBoundary";
 import ScheduleAgentModal from "./ScheduleAgentModal";
 import { useScheduler } from "../lib/useScheduler";
@@ -83,6 +85,7 @@ export default function AgentRunner({ agent }) {
   const [modelRecommendation, setModelRecommendation] = useState(null);
   const [analyserLoading, setAnalyserLoading] = useState(false);
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
+  const [batchMode, setBatchMode] = useState(false);
   const [showModelSwitcher, setShowModelSwitcher] = useState(false);
   const { addJob } = useScheduler();
 
@@ -115,6 +118,7 @@ export default function AgentRunner({ agent }) {
     setDuration(null);
     setCustomPrompt(agent.systemPrompt);
     setPlaygroundOpen(false);
+    setBatchMode(false);
 
     const defaults = {};
     agent.inputs.forEach((input) => {
@@ -324,6 +328,9 @@ export default function AgentRunner({ agent }) {
   };
 
   const IconComponent = Icons[agent.icon] || Icons.Bot;
+  const supportsBatchMode = agent.inputs.some((i) =>
+    ["text", "textarea", "code"].includes(i.type)
+  );
 
   return (
     <div className="max-w-3xl mx-auto animate-fade-in">
@@ -383,6 +390,36 @@ export default function AgentRunner({ agent }) {
         setModel={setSelectedModel}
       />
 
+      {supportsBatchMode && (
+        <div className="flex items-center gap-2 mb-4">
+          <button
+            onClick={() => setBatchMode((prev) => !prev)}
+            title="Run this agent across multiple inputs at once"
+            className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+              ${
+                batchMode
+                  ? "bg-accent/15 text-accent border border-accent/30"
+                  : "dark:text-text-secondary dark:hover:text-text-primary dark:hover:bg-surface-hover text-gray-500 hover:text-gray-900 hover:bg-gray-100 border border-transparent"
+              }`}
+          >
+            <Layers size={14} />
+            {batchMode ? "Exit Batch Mode" : "Batch Mode"}
+          </button>
+        </div>
+      )}
+
+      {batchMode ? (
+        <div className="mb-6">
+          <BatchModeRunner
+            agent={agent}
+            provider={agent.provider === "any" ? provider : agent.provider}
+            apiKey={apiKey}
+            selectedModel={selectedModel}
+            systemPrompt={customPrompt}
+          />
+        </div>
+      ) : (
+        <>
       {/* Input Form */}
       <div className="space-y-3 mb-4">
         {agent.inputs.map((input) => (
@@ -723,6 +760,18 @@ export default function AgentRunner({ agent }) {
           Schedule
         </button>
 
+        {/* Schedule button */}
+        <button
+          onClick={() => setScheduleModalOpen(true)}
+          title="Schedule this agent to run automatically"
+          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+            dark:text-text-secondary dark:hover:text-text-primary dark:hover:bg-surface-hover
+            text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+        >
+          <CalendarClock size={14} />
+          Schedule
+        </button>
+
         {duration && (
           <div className="flex items-center gap-1 text-[11px] dark:text-text-muted text-gray-400 ml-auto">
             <Clock size={11} />
@@ -872,6 +921,9 @@ export default function AgentRunner({ agent }) {
             </button>
           </div>
         </div>
+      )}
+
+      </>
       )}
 
       {/* Schedule Agent Modal */}

--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -93,9 +93,10 @@ export default function AgentRunner({ agent }) {
   const abortControllerRef = useRef(null);
 
   useKeyboardShortcuts({
-    'Control+Enter': () => {
-      if (canRun() && !loading) handleRun();
-    },
+  'Control+Enter': () => {
+    if (batchMode) return;
+    if (canRun() && !loading) handleRun();
+  },
     'Escape': () => {
       handleClear();
       setPlaygroundOpen(false);
@@ -746,18 +747,6 @@ export default function AgentRunner({ agent }) {
         >
           <RotateCcw size={14} />
           Clear
-        </button>
-
-        {/* Schedule button */}
-        <button
-          onClick={() => setScheduleModalOpen(true)}
-          title="Schedule this agent to run automatically"
-          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors
-            dark:text-text-secondary dark:hover:text-text-primary dark:hover:bg-surface-hover
-            text-gray-500 hover:text-gray-900 hover:bg-gray-100"
-        >
-          <CalendarClock size={14} />
-          Schedule
         </button>
 
         {/* Schedule button */}

--- a/src/components/BatchModeRunner.jsx
+++ b/src/components/BatchModeRunner.jsx
@@ -1,0 +1,384 @@
+import { useState, useRef, useMemo } from 'react'
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Upload,
+  Download,
+  StopCircle,
+  Zap,
+  FileText,
+} from 'lucide-react'
+import CustomSelect from './CustomSelect'
+import { runBatch, parsePastedLines, parseCSV, looksLikeHeader } from '../lib/batchRunner'
+import { exportBatchAsCSV, exportBatchAsMarkdown } from '../lib/exportBatch'
+
+const STATUS_COLORS = {
+  waiting: 'dark:text-text-muted text-gray-400',
+  running: 'text-accent',
+  done: 'text-emerald-400',
+  failed: 'text-red-400',
+}
+
+function StatusIcon({ status }) {
+  if (status === 'waiting') return <Clock size={13} className={STATUS_COLORS.waiting} />
+  if (status === 'running') return <Loader2 size={13} className="text-accent animate-spin" />
+  if (status === 'done') return <CheckCircle2 size={13} className={STATUS_COLORS.done} />
+  if (status === 'failed') return <XCircle size={13} className={STATUS_COLORS.failed} />
+  return null
+}
+
+// Field types that can sensibly hold one "row" of batch data
+const BATCHABLE_TYPES = ['text', 'textarea', 'code']
+
+export default function BatchModeRunner({ agent, provider, apiKey, selectedModel, systemPrompt }) {
+  const batchableFields = useMemo(
+    () => agent.inputs.filter((i) => BATCHABLE_TYPES.includes(i.type)),
+    [agent]
+  )
+
+  const [batchFieldId, setBatchFieldId] = useState(batchableFields[0]?.id || '')
+  const [fixedInputs, setFixedInputs] = useState({})
+  const [rawPaste, setRawPaste] = useState('')
+  const [items, setItems] = useState([]) // string[]
+  const [csvColumns, setCsvColumns] = useState(null) // {headers, rows} when a CSV is uploaded
+  const [csvColumnIndex, setCsvColumnIndex] = useState(0)
+  const [results, setResults] = useState([]) // [{input, status, output, error}]
+  const [running, setRunning] = useState(false)
+  const [hasRun, setHasRun] = useState(false)
+  const fileInputRef = useRef(null)
+  const abortControllerRef = useRef(null)
+
+  const otherFields = agent.inputs.filter((i) => i.id !== batchFieldId)
+
+  const updateFixedInput = (id, value) => {
+    setFixedInputs((prev) => ({ ...prev, [id]: value }))
+  }
+
+  const handleFileUpload = (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (evt) => {
+      const text = evt.target.result
+      if (file.name.toLowerCase().endsWith('.csv')) {
+        const parsed = parseCSV(text)
+        if (looksLikeHeader(parsed.headers) && parsed.rows.length > 0) {
+          setCsvColumns(parsed)
+          setCsvColumnIndex(0)
+          setItems(parsed.rows.map((r) => r[0]).filter(Boolean))
+        } else {
+          // Treat as headerless — every row's first cell is an item
+          const allRows = [parsed.headers, ...parsed.rows].filter(Boolean)
+          setCsvColumns(null)
+          setItems(allRows.map((r) => r[0]).filter(Boolean))
+        }
+      } else {
+        setCsvColumns(null)
+        setItems(parsePastedLines(text))
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  const handlePasteChange = (val) => {
+    setRawPaste(val)
+    setCsvColumns(null)
+    setItems(parsePastedLines(val))
+  }
+
+  const handleCsvColumnChange = (indexStr) => {
+    const index = Number(indexStr)
+    setCsvColumnIndex(index)
+    if (csvColumns) {
+      setItems(csvColumns.rows.map((r) => r[index]).filter(Boolean))
+    }
+  }
+
+  const canRun = () => {
+    if (!apiKey || items.length === 0 || !batchFieldId) return false
+    return agent.inputs
+      .filter((i) => i.required && i.id !== batchFieldId)
+      .every((i) => {
+        const v = fixedInputs[i.id]
+        if (Array.isArray(v)) return v.length > 0
+        return v && String(v).trim() !== ''
+      })
+  }
+
+  const handleRun = async () => {
+    setRunning(true)
+    setHasRun(true)
+    setResults(items.map((item) => ({ input: item, status: 'waiting' })))
+
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    const onItemUpdate = (index, patch) => {
+      setResults((prev) => prev.map((r, i) => (i === index ? { ...r, ...patch } : r)))
+    }
+
+    try {
+      await runBatch({
+        items,
+        agent,
+        fixedInputs,
+        batchFieldId,
+        provider,
+        model: selectedModel,
+        apiKey,
+        systemPrompt,
+        concurrency: 3,
+        onItemUpdate,
+        signal: controller.signal,
+      })
+    } finally {
+      setRunning(false)
+      abortControllerRef.current = null
+    }
+  }
+
+  const handleStop = () => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+      abortControllerRef.current = null
+    }
+    setRunning(false)
+  }
+
+  const completedCount = results.filter((r) => r.status === 'done' || r.status === 'failed').length
+  const allDone = hasRun && !running && completedCount === results.length && results.length > 0
+
+  return (
+    <div className="space-y-4">
+      {/* Batch field selector (only shown if there's a choice to make) */}
+      {batchableFields.length > 1 && (
+        <div>
+          <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1.5">
+            Which field varies per item?
+          </label>
+          <CustomSelect
+            value={batchFieldId}
+            onChange={setBatchFieldId}
+            options={batchableFields.map((f) => ({ value: f.id, label: f.label }))}
+            className="w-full sm:w-64"
+            triggerClassName="h-9"
+          />
+        </div>
+      )}
+
+      {/* Fixed/shared fields, reused for every item */}
+      {otherFields.length > 0 && (
+        <div className="space-y-3 p-3 rounded-lg border dark:border-border dark:bg-surface-input/30 border-gray-200 bg-gray-50">
+          <p className="text-[11px] font-medium dark:text-text-muted text-gray-400">
+            These fields stay the same for every item in the batch:
+          </p>
+          {otherFields.map((input) => (
+            <div key={input.id}>
+              <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+                {input.label}
+                {input.required && <span className="text-error ml-0.5">*</span>}
+              </label>
+              {input.type === 'select' ? (
+                <CustomSelect
+                  value={fixedInputs[input.id] || input.defaultValue || ''}
+                  onChange={(val) => updateFixedInput(input.id, val)}
+                  options={input.options || []}
+                  className="w-full sm:w-64"
+                  triggerClassName="h-9"
+                />
+              ) : input.type === 'multiselect' ? (
+                <div className="flex flex-wrap gap-2">
+                  {input.options?.map((opt) => {
+                    const selected = (fixedInputs[input.id] || input.defaultValue || []).includes(opt)
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        onClick={() => {
+                          const current = fixedInputs[input.id] || input.defaultValue || []
+                          updateFixedInput(
+                            input.id,
+                            current.includes(opt)
+                              ? current.filter((o) => o !== opt)
+                              : [...current, opt]
+                          )
+                        }}
+                        className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all border
+                          ${
+                            selected
+                              ? 'bg-accent/15 text-accent border-accent/30'
+                              : 'dark:bg-surface-input dark:text-text-secondary dark:border-border bg-white text-gray-500 border-gray-200'
+                          }`}
+                      >
+                        {selected && '✓ '}
+                        {opt}
+                      </button>
+                    )
+                  })}
+                </div>
+              ) : (
+                <input
+                  type="text"
+                  value={fixedInputs[input.id] || ''}
+                  onChange={(e) => updateFixedInput(input.id, e.target.value)}
+                  placeholder={input.placeholder}
+                  className="w-full h-9 px-3 rounded-md text-sm transition-colors
+                    dark:bg-surface-input dark:border-border dark:text-text-primary
+                    bg-white border border-gray-200 text-gray-900
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Batch input: paste or upload */}
+      <div>
+        <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1.5">
+          Batch items — one per line, or upload a .csv / .txt file
+        </label>
+        <textarea
+          value={rawPaste}
+          onChange={(e) => handlePasteChange(e.target.value)}
+          placeholder={'Item 1\nItem 2\nItem 3...'}
+          rows={6}
+          disabled={running}
+          className="w-full px-3 py-2.5 rounded-lg text-sm transition-colors resize-y
+            dark:bg-surface-input dark:border-border dark:text-text-primary
+            bg-gray-50 border border-gray-200 text-gray-900
+            focus:ring-1 focus:ring-accent focus:border-accent outline-none
+            disabled:opacity-60"
+        />
+        <div className="flex items-center gap-3 mt-2">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={running}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
+              dark:bg-surface-input dark:text-text-secondary dark:border-border
+              bg-white border border-gray-200 text-gray-600 hover:text-gray-900 disabled:opacity-60"
+          >
+            <Upload size={12} />
+            Upload .csv / .txt
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,.txt"
+            onChange={handleFileUpload}
+            className="hidden"
+          />
+          {items.length > 0 && (
+            <span className="text-[11px] dark:text-text-muted text-gray-400">
+              {items.length} item{items.length !== 1 ? 's' : ''} detected
+            </span>
+          )}
+        </div>
+
+        {/* Column picker for CSVs with headers */}
+        {csvColumns && (
+          <div className="mt-2 flex items-center gap-2">
+            <span className="text-[11px] dark:text-text-muted text-gray-400">Use column:</span>
+            <CustomSelect
+              value={String(csvColumnIndex)}
+              onChange={handleCsvColumnChange}
+              options={csvColumns.headers.map((h, i) => ({ value: String(i), label: h }))}
+              triggerClassName="h-7 text-xs"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Run / Stop / Progress */}
+      <div className="flex items-center gap-2">
+        {running ? (
+          <button
+            onClick={handleStop}
+            className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold
+              text-white bg-red-500 hover:bg-red-600 transition-all active:scale-[0.98]"
+          >
+            <StopCircle size={16} />
+            Stop
+          </button>
+        ) : (
+          <button
+            onClick={handleRun}
+            disabled={!canRun()}
+            className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white
+              bg-accent hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed
+              transition-all active:scale-[0.98]"
+          >
+            <Zap size={16} />
+            Run Batch ({items.length})
+          </button>
+        )}
+
+        {hasRun && (
+          <span className="text-xs dark:text-text-secondary text-gray-500">
+            {completedCount} of {results.length} complete
+          </span>
+        )}
+
+        {allDone && (
+          <div className="flex items-center gap-2 ml-auto">
+            <button
+              onClick={() => exportBatchAsCSV(agent.name, results)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
+                dark:bg-surface-input dark:text-text-secondary dark:border-border
+                bg-white border border-gray-200 text-gray-600 hover:text-gray-900"
+            >
+              <Download size={12} />
+              Export CSV
+            </button>
+            <button
+              onClick={() => exportBatchAsMarkdown(agent.name, results)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
+                dark:bg-surface-input dark:text-text-secondary dark:border-border
+                bg-white border border-gray-200 text-gray-600 hover:text-gray-900"
+            >
+              <FileText size={12} />
+              Export Markdown
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Results list */}
+      {hasRun && (
+        <div className="space-y-2">
+          {results.map((r, i) => (
+            <div
+              key={i}
+              className="rounded-lg border dark:bg-surface-card dark:border-border bg-white border-gray-200 overflow-hidden"
+            >
+              <div className="flex items-center gap-2 px-3 py-2 border-b dark:border-border border-gray-100">
+                <span className="flex items-center justify-center w-5 h-5 rounded-full bg-accent/10 text-[10px] font-bold text-accent flex-shrink-0">
+                  {i + 1}
+                </span>
+                <span className="text-xs dark:text-text-primary text-gray-900 truncate flex-1">
+                  {r.input}
+                </span>
+                <StatusIcon status={r.status} />
+                <span className={`text-[11px] font-medium capitalize ${STATUS_COLORS[r.status] || ''}`}>
+                  {r.status}
+                </span>
+              </div>
+              {r.status === 'done' && r.output && (
+                <div className="px-3 py-2 text-xs dark:text-text-secondary text-gray-600 whitespace-pre-wrap max-h-32 overflow-y-auto">
+                  {r.output}
+                </div>
+              )}
+              {r.status === 'failed' && r.error && (
+                <div className="px-3 py-2 text-xs text-red-400">{r.error}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/BatchModeRunner.jsx
+++ b/src/components/BatchModeRunner.jsx
@@ -11,7 +11,7 @@ import {
   FileText,
 } from 'lucide-react'
 import CustomSelect from './CustomSelect'
-import { runBatch, parsePastedLines, parseCSV, looksLikeHeader } from '../lib/batchRunner'
+import { runBatch, parsePastedLines, parseCSV } from '../lib/batchRunner'
 import { exportBatchAsCSV, exportBatchAsMarkdown } from '../lib/exportBatch'
 
 const STATUS_COLORS = {
@@ -42,7 +42,8 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
   const [fixedInputs, setFixedInputs] = useState({})
   const [rawPaste, setRawPaste] = useState('')
   const [items, setItems] = useState([]) // string[]
-  const [csvColumns, setCsvColumns] = useState(null) // {headers, rows} when a CSV is uploaded
+  const [csvRawRows, setCsvRawRows] = useState(null) // string[][] from parseCSV, before header decision
+  const [csvHasHeader, setCsvHasHeader] = useState(false)
   const [csvColumnIndex, setCsvColumnIndex] = useState(0)
   const [results, setResults] = useState([]) // [{input, status, output, error}]
   const [running, setRunning] = useState(false)
@@ -56,6 +57,26 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
     setFixedInputs((prev) => ({ ...prev, [id]: value }))
   }
 
+  // Resolve a fixed field's effective value: explicit user input, else the
+  // field's defaultValue, else a sensible empty value. This matters because
+  // shared fields show their defaultValue in the UI even before the user
+  // touches them — canRun() and the run payload must agree with what's shown.
+  const resolveFixedValue = (input) => {
+    const current = fixedInputs[input.id]
+    if (current !== undefined) return current
+    if (input.defaultValue !== undefined) return input.defaultValue
+    return input.type === 'multiselect' ? [] : ''
+  }
+
+  // Derived view of the CSV: which row is the header (if any), and the data rows
+  const csvHeaders = csvHasHeader ? csvRawRows?.[0] : null
+  const csvDataRows = csvHasHeader ? csvRawRows?.slice(1) : csvRawRows
+
+  const recomputeItemsFromCsv = (rawRows, hasHeader, columnIndex) => {
+    const dataRows = hasHeader ? rawRows.slice(1) : rawRows
+    setItems(dataRows.map((r) => r[columnIndex]).filter(Boolean))
+  }
+
   const handleFileUpload = (e) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -65,18 +86,12 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
       const text = evt.target.result
       if (file.name.toLowerCase().endsWith('.csv')) {
         const parsed = parseCSV(text)
-        if (looksLikeHeader(parsed.headers) && parsed.rows.length > 0) {
-          setCsvColumns(parsed)
-          setCsvColumnIndex(0)
-          setItems(parsed.rows.map((r) => r[0]).filter(Boolean))
-        } else {
-          // Treat as headerless — every row's first cell is an item
-          const allRows = [parsed.headers, ...parsed.rows].filter(Boolean)
-          setCsvColumns(null)
-          setItems(allRows.map((r) => r[0]).filter(Boolean))
-        }
+        setCsvRawRows(parsed.rows)
+        setCsvHasHeader(false) // safe default: never assume a header, never drop the first row
+        setCsvColumnIndex(0)
+        setItems(parsed.rows.map((r) => r[0]).filter(Boolean))
       } else {
-        setCsvColumns(null)
+        setCsvRawRows(null)
         setItems(parsePastedLines(text))
       }
     }
@@ -85,15 +100,23 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
 
   const handlePasteChange = (val) => {
     setRawPaste(val)
-    setCsvColumns(null)
+    setCsvRawRows(null)
     setItems(parsePastedLines(val))
   }
 
   const handleCsvColumnChange = (indexStr) => {
     const index = Number(indexStr)
     setCsvColumnIndex(index)
-    if (csvColumns) {
-      setItems(csvColumns.rows.map((r) => r[index]).filter(Boolean))
+    if (csvRawRows) {
+      recomputeItemsFromCsv(csvRawRows, csvHasHeader, index)
+    }
+  }
+
+  const handleToggleCsvHeader = () => {
+    const next = !csvHasHeader
+    setCsvHasHeader(next)
+    if (csvRawRows) {
+      recomputeItemsFromCsv(csvRawRows, next, csvColumnIndex)
     }
   }
 
@@ -102,7 +125,7 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
     return agent.inputs
       .filter((i) => i.required && i.id !== batchFieldId)
       .every((i) => {
-        const v = fixedInputs[i.id]
+        const v = resolveFixedValue(i)
         if (Array.isArray(v)) return v.length > 0
         return v && String(v).trim() !== ''
       })
@@ -120,11 +143,17 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
       setResults((prev) => prev.map((r, i) => (i === index ? { ...r, ...patch } : r)))
     }
 
+    // Include resolved defaults for any fixed field the user never touched,
+    // so the run payload matches what's actually shown in the UI.
+    const mergedFixedInputs = Object.fromEntries(
+      otherFields.map((input) => [input.id, resolveFixedValue(input)])
+    )
+
     try {
       await runBatch({
         items,
         agent,
-        fixedInputs,
+        fixedInputs: mergedFixedInputs,
         batchFieldId,
         provider,
         model: selectedModel,
@@ -219,10 +248,23 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
                     )
                   })}
                 </div>
+              ) : input.type === 'textarea' || input.type === 'code' ? (
+                <textarea
+                  value={fixedInputs[input.id] ?? input.defaultValue ?? ''}
+                  onChange={(e) => updateFixedInput(input.id, e.target.value)}
+                  placeholder={input.placeholder}
+                  rows={input.type === 'code' ? 8 : 4}
+                  spellCheck={input.type !== 'code'}
+                  className={`w-full px-3 py-2 rounded-md text-sm transition-colors resize-y
+                    dark:bg-surface-input dark:border-border dark:text-text-primary
+                    bg-white border border-gray-200 text-gray-900
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none
+                    ${input.type === 'code' ? 'font-mono' : ''}`}
+                />
               ) : (
                 <input
                   type="text"
-                  value={fixedInputs[input.id] || ''}
+                  value={fixedInputs[input.id] ?? input.defaultValue ?? ''}
                   onChange={(e) => updateFixedInput(input.id, e.target.value)}
                   placeholder={input.placeholder}
                   className="w-full h-9 px-3 rounded-md text-sm transition-colors
@@ -279,16 +321,34 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
           )}
         </div>
 
-        {/* Column picker for CSVs with headers */}
-        {csvColumns && (
-          <div className="mt-2 flex items-center gap-2">
-            <span className="text-[11px] dark:text-text-muted text-gray-400">Use column:</span>
-            <CustomSelect
-              value={String(csvColumnIndex)}
-              onChange={handleCsvColumnChange}
-              options={csvColumns.headers.map((h, i) => ({ value: String(i), label: h }))}
-              triggerClassName="h-7 text-xs"
-            />
+        {/* Header confirmation + column picker for uploaded CSVs */}
+        {csvRawRows && csvRawRows[0]?.length > 1 && (
+          <div className="mt-2 space-y-2">
+            <label className="flex items-center gap-2 text-[11px] dark:text-text-secondary text-gray-500 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={csvHasHeader}
+                onChange={handleToggleCsvHeader}
+                className="accent-accent"
+              />
+              First row is a header (not a data item)
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] dark:text-text-muted text-gray-400">Use column:</span>
+              <CustomSelect
+                value={String(csvColumnIndex)}
+                onChange={handleCsvColumnChange}
+                options={
+                  csvHasHeader
+                    ? csvHeaders.map((h, i) => ({ value: String(i), label: h || `Column ${i + 1}` }))
+                    : csvRawRows[0].map((_, i) => ({ value: String(i), label: `Column ${i + 1}` }))
+                }
+                triggerClassName="h-7 text-xs"
+              />
+            </div>
+            <p className="text-[10px] dark:text-text-muted text-gray-400">
+              {csvDataRows?.length || 0} row{csvDataRows?.length !== 1 ? 's' : ''} will be used as batch items.
+            </p>
           </div>
         )}
       </div>

--- a/src/components/BatchModeRunner.jsx
+++ b/src/components/BatchModeRunner.jsx
@@ -321,8 +321,8 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
           )}
         </div>
 
-        {/* Header confirmation + column picker for uploaded CSVs */}
-        {csvRawRows && csvRawRows[0]?.length > 1 && (
+        {/* Header confirmation (always shown for CSVs) + column picker (multi-column only) */}
+        {csvRawRows && csvRawRows.length > 0 && (
           <div className="mt-2 space-y-2">
             <label className="flex items-center gap-2 text-[11px] dark:text-text-secondary text-gray-500 cursor-pointer">
               <input
@@ -333,19 +333,21 @@ export default function BatchModeRunner({ agent, provider, apiKey, selectedModel
               />
               First row is a header (not a data item)
             </label>
-            <div className="flex items-center gap-2">
-              <span className="text-[11px] dark:text-text-muted text-gray-400">Use column:</span>
-              <CustomSelect
-                value={String(csvColumnIndex)}
-                onChange={handleCsvColumnChange}
-                options={
-                  csvHasHeader
-                    ? csvHeaders.map((h, i) => ({ value: String(i), label: h || `Column ${i + 1}` }))
-                    : csvRawRows[0].map((_, i) => ({ value: String(i), label: `Column ${i + 1}` }))
-                }
-                triggerClassName="h-7 text-xs"
-              />
-            </div>
+            {csvRawRows[0]?.length > 1 && (
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] dark:text-text-muted text-gray-400">Use column:</span>
+                <CustomSelect
+                  value={String(csvColumnIndex)}
+                  onChange={handleCsvColumnChange}
+                  options={
+                    csvHasHeader
+                      ? csvHeaders.map((h, i) => ({ value: String(i), label: h || `Column ${i + 1}` }))
+                      : csvRawRows[0].map((_, i) => ({ value: String(i), label: `Column ${i + 1}` }))
+                  }
+                  triggerClassName="h-7 text-xs"
+                />
+              </div>
+            )}
             <p className="text-[10px] dark:text-text-muted text-gray-400">
               {csvDataRows?.length || 0} row{csvDataRows?.length !== 1 ? 's' : ''} will be used as batch items.
             </p>

--- a/src/lib/batchRunner.js
+++ b/src/lib/batchRunner.js
@@ -1,0 +1,172 @@
+/**
+ * Batch Runner — core logic for running an agent across many inputs.
+ * No UI here. Used by BatchModeRunner.jsx.
+ */
+
+import { runAgent } from './llmAdapter'
+
+/**
+ * Parse pasted multi-line text into batch items.
+ * One non-empty line = one item.
+ */
+export function parsePastedLines(raw) {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+/**
+ * Minimal CSV parser — no external dependency.
+ * Handles quoted fields, escaped quotes (""), and commas inside quotes.
+ * Returns { headers: string[]|null, rows: string[][] }
+ */
+export function parseCSV(text) {
+  const rows = []
+  let row = []
+  let field = ''
+  let inQuotes = false
+
+  const pushField = () => {
+    row.push(field)
+    field = ''
+  }
+  const pushRow = () => {
+    pushField()
+    rows.push(row)
+    row = []
+  }
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+    const next = text[i + 1]
+
+    if (inQuotes) {
+      if (char === '"' && next === '"') {
+        field += '"'
+        i++
+      } else if (char === '"') {
+        inQuotes = false
+      } else {
+        field += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === ',') {
+        pushField()
+      } else if (char === '\r') {
+        // skip, \n will trigger row end
+      } else if (char === '\n') {
+        pushRow()
+      } else {
+        field += char
+      }
+    }
+  }
+
+  // Final field/row if file doesn't end with newline
+  if (field.length > 0 || row.length > 0) {
+    pushRow()
+  }
+
+  const nonEmptyRows = rows.filter((r) => r.some((cell) => cell.trim() !== ''))
+  if (nonEmptyRows.length === 0) return { headers: null, rows: [] }
+
+  return { headers: nonEmptyRows[0], rows: nonEmptyRows.slice(1) }
+}
+
+/**
+ * Detect whether a parsed CSV's first row looks like a header
+ * (heuristic: no purely numeric-looking cells, reasonably short).
+ */
+export function looksLikeHeader(firstRow) {
+  if (!firstRow) return false
+  return firstRow.every((cell) => cell.trim().length > 0 && cell.trim().length < 80)
+}
+
+/**
+ * Build the full user message for one batch item, substituting the
+ * batch field value into the fixed inputs and formatting the same way
+ * AgentRunner's buildUserMessage does.
+ */
+export function buildBatchUserMessage(agent, fixedInputs, batchFieldId, itemValue) {
+  const parts = []
+  agent.inputs.forEach((input) => {
+    const val = input.id === batchFieldId ? itemValue : fixedInputs[input.id]
+    if (!val || (Array.isArray(val) && val.length === 0)) return
+
+    const sanitizedVal = typeof val === 'string' ? val.trim() : val
+    if (sanitizedVal === '') return
+
+    parts.push(
+      Array.isArray(sanitizedVal)
+        ? `${input.label}: ${sanitizedVal.join(', ')}`
+        : `${input.label}: ${sanitizedVal}`
+    )
+  })
+
+  return parts.join('\n\n').trim().replace(/\n{3,}/g, '\n\n')
+}
+
+/**
+ * Run a batch of items against an agent with limited concurrency.
+ *
+ * @param {Object} params
+ * @param {string[]} params.items - the per-row values for the batch field
+ * @param {Object} params.agent
+ * @param {Object} params.fixedInputs - values for all non-batch fields
+ * @param {string} params.batchFieldId
+ * @param {string} params.provider
+ * @param {string} params.model
+ * @param {string} params.apiKey
+ * @param {string} params.systemPrompt
+ * @param {number} [params.concurrency=3]
+ * @param {(index: number, patch: object) => void} params.onItemUpdate
+ * @param {AbortSignal} [params.signal]
+ * @returns {Promise<void>}
+ */
+export async function runBatch({
+  items,
+  agent,
+  fixedInputs,
+  batchFieldId,
+  provider,
+  model,
+  apiKey,
+  systemPrompt,
+  concurrency = 3,
+  onItemUpdate,
+  signal,
+}) {
+  let cursor = 0
+
+  async function worker() {
+    while (cursor < items.length) {
+      if (signal?.aborted) return
+      const index = cursor++
+      const itemValue = items[index]
+
+      onItemUpdate(index, { status: 'running' })
+
+      try {
+        const userMessage = buildBatchUserMessage(agent, fixedInputs, batchFieldId, itemValue)
+        const result = await runAgent(
+          { provider, model, apiKey, systemPrompt, userMessage },
+          { signal }
+        )
+        if (signal?.aborted) return
+        onItemUpdate(index, { status: 'done', output: result.content })
+      } catch (err) {
+        if (signal?.aborted) return
+        onItemUpdate(index, {
+          status: 'failed',
+          error: err?.message || err?.detail || 'Failed to process this item.',
+        })
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+}

--- a/src/lib/batchRunner.js
+++ b/src/lib/batchRunner.js
@@ -65,25 +65,28 @@ export function parseCSV(text) {
     }
   }
 
-  // Final field/row if file doesn't end with newline
   if (field.length > 0 || row.length > 0) {
     pushRow()
   }
 
   const nonEmptyRows = rows.filter((r) => r.some((cell) => cell.trim() !== ''))
-  if (nonEmptyRows.length === 0) return { headers: null, rows: [] }
-
-  return { headers: nonEmptyRows[0], rows: nonEmptyRows.slice(1) }
+  return { rows: nonEmptyRows }
 }
 
 /**
  * Detect whether a parsed CSV's first row looks like a header
  * (heuristic: no purely numeric-looking cells, reasonably short).
  */
-export function looksLikeHeader(firstRow) {
-  if (!firstRow) return false
-  return firstRow.every((cell) => cell.trim().length > 0 && cell.trim().length < 80)
-}
+
+/**
+ * NOTE: We deliberately do NOT try to auto-detect whether a CSV's first
+ * row is a header by inspecting its content. Free-text items (e.g. a
+ * resume snippet like "Doe, Jane - Software Engineer") are indistinguishable
+ * from a genuine header row using any content heuristic, and guessing wrong
+ * silently drops the first real item. Instead, the UI always shows the user
+ * the parsed first row and lets them confirm whether to treat it as a
+ * header — see the "First row is a header" toggle in BatchModeRunner.
+ */
 
 /**
  * Build the full user message for one batch item, substituting the

--- a/src/lib/exportBatch.js
+++ b/src/lib/exportBatch.js
@@ -1,0 +1,84 @@
+/**
+ * Export batch results as CSV or Markdown.
+ * Mirrors the pattern in exportMarkdown.js.
+ */
+
+function slugifyFilename(name) {
+  return (
+    name
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '') || 'batch'
+  )
+}
+
+function downloadBlob(content, mimeType, filename) {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function csvEscape(value) {
+  const str = String(value ?? '')
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+/**
+ * @param {string} agentName
+ * @param {Array<{input: string, status: string, output?: string, error?: string}>} results
+ */
+export function exportBatchAsCSV(agentName, results) {
+  const filename = `${slugifyFilename(agentName)}-batch-results.csv`
+
+  const header = ['#', 'Input', 'Status', 'Output', 'Error']
+  const rows = results.map((r, i) => [
+    i + 1,
+    r.input,
+    r.status,
+    r.output || '',
+    r.error || '',
+  ])
+
+  const csv = [header, ...rows]
+    .map((row) => row.map(csvEscape).join(','))
+    .join('\n')
+
+  downloadBlob(csv, 'text/csv', filename)
+}
+
+/**
+ * @param {string} agentName
+ * @param {Array<{input: string, status: string, output?: string, error?: string}>} results
+ */
+export function exportBatchAsMarkdown(agentName, results) {
+  const date = new Date().toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+
+  const filename = `${slugifyFilename(agentName)}-batch-results.md`
+
+  const sections = results
+    .map((r, i) => {
+      const heading = `## Item ${i + 1} — ${r.status === 'done' ? '✅ Success' : r.status === 'failed' ? '❌ Failed' : '⏳ ' + r.status}`
+      const inputBlock = `**Input:**\n\n${r.input}`
+      const bodyBlock =
+        r.status === 'failed'
+          ? `**Error:**\n\n${r.error || 'Unknown error'}`
+          : `**Output:**\n\n${r.output || '(empty)'}`
+      return `${heading}\n\n${inputBlock}\n\n${bodyBlock}`
+    })
+    .join('\n\n---\n\n')
+
+  const content = `# ${agentName} — Batch Results\nGenerated on ${date}\n${results.length} items processed\n\n${sections}`
+
+  downloadBlob(content, 'text/markdown', filename)
+}


### PR DESCRIPTION
## What does this PR do?

Adds a **Batch Input Mode** to AgentRunner so agents can be run across many inputs at once instead of one at a time, closing #612.

When enabled, a "Batch Mode" toggle appears for any agent that has at least one `text`/`textarea`/`code` input. For agents with more than one such field (e.g. Resume Screener's `job_description` + `resume`), the user picks which field varies per item, every other field stays fixed and is reused for every row in the batch.

Users can either paste multiple items (one per line) or upload a `.csv`/`.txt` file. For CSV uploads, the first row is **never assumed to be a header** , content-based header detection is unreliable for free-text items (a line like `"Resume of Alice, Engineer"` is indistinguishable from a genuine header), so guessing wrong would silently drop the first real item. Instead there's an explicit "First row is a header" checkbox that defaults to unchecked, so no data is ever lost by default.

Items run with limited concurrency (3 at a time) through the existing `runAgent()` adapter, no changes to `llmAdapter.js` itself. Each item shows a live status (waiting → running → done/failed), and a "X of Y complete" progress line updates as the batch runs. Results can be exported as CSV or Markdown, following the same Blob/download pattern already used in `exportMarkdown.js`. A Stop button aborts the in-flight batch via `AbortController`, matching the existing single-run Stop behavior.

Single-run mode is untouched, the existing input form, output rendering, Prompt Playground, Model Analyser, and Schedule flow are all wrapped in a `{batchMode ? ... : (...)}` conditional with no changes to their internals, so toggling Batch Mode off restores the exact original UI and behavior.

### Related Issue
Closes #612 

### Files changed
- **`src/lib/batchRunner.js`** (new) : dependency-free CSV/line parsing, builds per-item prompts, runs the batch with a concurrency-limited worker pool against `runAgent()`
- **`src/lib/exportBatch.js`** (new) : exports batch results as CSV or Markdown
- **`src/components/BatchModeRunner.jsx`** (new) : batch UI: field picker, fixed-field inputs, paste/upload, header checkbox, progress, per-item results, export buttons
- **`src/components/AgentRunner.jsx`** (modified) : adds an always-visible Batch Mode toggle and renders `BatchModeRunner` in place of the single-run form when active

## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Documentation
- [x] Other (new feature)

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)

<img width="1918" height="911" alt="image" src="https://github.com/user-attachments/assets/c2ebfdc7-fbcd-4b30-a774-4cf30edcb212" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Batch Mode** for text/textarea/code-capable agents, with a toggle that swaps the single-run form for a batch runner.
  * Batch items can be entered via pasted newline values or uploaded from **CSV/TXT** (CSV supports header handling and choosing the column to vary).
  * Added batch result **export** to **CSV** and **Markdown**, plus per-item progress/status with a **Stop** control.
* **Bug Fixes**
  * Improved **Control+Enter** behavior so it won’t trigger single-run while batch mode is enabled.
  * Fixed a UI rendering issue so related agent modals remain correctly positioned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->