### PR TITLE
feat: add Custom Suite Generator to Suites page

### DIFF
--- a/src/lib/customSuiteGenerator.js
+++ b/src/lib/customSuiteGenerator.js
@@ -1,0 +1,60 @@
+import { streamAgent } from "./llmAdapter";
+import { suites } from "../suites/suitesData";
+
+const MODEL_DEFAULTS = {
+  gemini: "gemini-2.5-flash",
+  anthropic: "claude-3.5-haiku",
+  openai: "gpt-4o-mini",
+};
+
+export async function generateCustomSuite(goal, apiKey, provider) {
+  // Building a flat list of all agents across all suites
+  const agentList = suites.map((suite) => ({
+    suiteId: suite.id,
+    suiteName: suite.name,
+    agents: suite.agents,
+  }));
+
+  const agentContext = agentList
+    .map((s) => `${s.suiteName}: ${s.agents.join(", ")}`)
+    .join("\n");
+
+  const systemPrompt = `You are an AI assistant that helps users find the best combination of agents for their goal.
+
+You have access to these agents organized by suite:
+${agentContext}
+
+When given a user's goal, pick 4-6 most relevant agent IDs from the list above.
+
+Always respond in this EXACT JSON format and nothing else:
+{
+  "title": "Short title for this custom suite",
+  "description": "One sentence describing what this suite helps the user achieve",
+  "agents": [
+    { "id": "agent-id-here", "reason": "One line reason why this agent helps" },
+    { "id": "agent-id-here", "reason": "One line reason why this agent helps" }
+  ]
+}
+
+Rules:
+- Only use agent IDs that exist in the list above
+- Pick 4-6 agents maximum
+- Order them logically — what should the user do first, second, etc.
+- Keep reasons short and specific to the user's goal
+- Return ONLY valid JSON, no markdown, no extra text`;
+
+  const userMessage = `My goal is: ${goal}`;
+
+  const result = await streamAgent({
+    provider,
+    apiKey,
+    model: MODEL_DEFAULTS[provider] || "gemini-2.5-flash",
+    systemPrompt,
+    userMessage,
+    onChunk: () => {},
+  });
+
+  // Parse the JSON response
+  const clean = result.content.replace(/```json|```/g, "").trim();
+  return JSON.parse(clean);
+}

--- a/src/pages/SuitesPage.jsx
+++ b/src/pages/SuitesPage.jsx
@@ -1,3 +1,11 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Sparkles, ArrowRight, Code2, BarChart3, TrendingUp, DollarSign, Palette, PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2, Wand2, Loader2 } from 'lucide-react'
+import { suites } from '../suites/suitesData'
+import SuiteWizard from '../components/SuiteWizard'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+import { generateCustomSuite } from '../lib/customSuiteGenerator'
+import { useApiKey } from '../lib/useApiKey'
 export default function SuitesPage() {
   useDocumentTitle('Suites')
   const navigate = useNavigate()

--- a/src/pages/SuitesPage.jsx
+++ b/src/pages/SuitesPage.jsx
@@ -6,6 +6,19 @@ import SuiteWizard from '../components/SuiteWizard'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { generateCustomSuite } from '../lib/customSuiteGenerator'
 import { useApiKey } from '../lib/useApiKey'
+
+// Map icon name string → Lucide component
+const SUITE_ICONS = {
+  Code2, BarChart3, TrendingUp, DollarSign, Palette,
+  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
+}
+
+/**
+ * SuitesPage
+ *
+ * BROWSE state — shows all suite cards
+ * QUIZ state   — shows SuiteWizard for the selected suite
+ */
 export default function SuitesPage() {
   useDocumentTitle('Suites')
   const navigate = useNavigate()

--- a/src/pages/SuitesPage.jsx
+++ b/src/pages/SuitesPage.jsx
@@ -1,26 +1,29 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Sparkles, ArrowRight, Code2, BarChart3, TrendingUp, DollarSign, Palette, PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2 } from 'lucide-react'
-import { suites } from '../suites/suitesData'
-import SuiteWizard from '../components/SuiteWizard'
-import { useDocumentTitle } from '../lib/useDocumentTitle'
-
-// Map icon name string → Lucide component
-const SUITE_ICONS = {
-  Code2, BarChart3, TrendingUp, DollarSign, Palette,
-  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
-}
-
-/**
- * SuitesPage
- *
- * BROWSE state — shows all suite cards
- * QUIZ state   — shows SuiteWizard for the selected suite
- */
 export default function SuitesPage() {
   useDocumentTitle('Suites')
   const navigate = useNavigate()
-  const [activeSuite, setActiveSuite] = useState(null) // suite object | null
+  const { apiKey, provider } = useApiKey()
+  const [activeSuite, setActiveSuite] = useState(null)
+
+  // Custom suite generator state
+  const [goal, setGoal] = useState('')
+  const [customSuite, setCustomSuite] = useState(null)
+  const [generating, setGenerating] = useState(false)
+  const [generatorError, setGeneratorError] = useState(null)
+
+  const handleGenerateSuite = async () => {
+    if (!goal.trim() || !apiKey) return
+    setGenerating(true)
+    setCustomSuite(null)
+    setGeneratorError(null)
+    try {
+      const result = await generateCustomSuite(goal, apiKey, provider)
+      setCustomSuite(result)
+    } catch (err) {
+      setGeneratorError("Couldn't generate your suite. Please try again.")
+    } finally {
+      setGenerating(false)
+    }
+  }
 
   // ── QUIZ state
   if (activeSuite) {
@@ -49,6 +52,109 @@ export default function SuitesPage() {
           Answer a few questions and we'll recommend the best agents for your needs —
           or browse by suite below.
         </p>
+      </div>
+
+      {/* Custom Suite Generator */}
+      <div className="mb-10 rounded-xl border dark:bg-surface-card dark:border-border bg-white border-gray-200 p-6">
+        <div className="flex items-center gap-2 mb-1">
+          <Wand2 size={16} className="text-accent" />
+          <h2 className="text-sm font-bold dark:text-text-primary text-gray-900">
+            Build Your Own Suite
+          </h2>
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-accent/10 text-accent border border-accent/20">
+            Beta
+          </span>
+        </div>
+        <p className="text-xs dark:text-text-secondary text-gray-500 mb-4">
+          Don't see a suite for your goal? Describe it and we'll pick the best agents for you.
+        </p>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleGenerateSuite()}
+            placeholder="e.g. I want to prepare for a Goldman Sachs interview..."
+            className="flex-1 h-9 pl-3 pr-3 rounded-md text-sm transition-colors
+              dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
+              bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
+              focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+          />
+          <button
+            onClick={handleGenerateSuite}
+            disabled={!goal.trim() || !apiKey || generating}
+            className="flex items-center gap-2 px-4 py-2 rounded-md text-xs font-semibold text-white
+              bg-accent hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed
+              transition-all duration-200 active:scale-[0.98]"
+          >
+            {generating ? (
+              <Loader2 size={13} className="animate-spin" />
+            ) : (
+              <Wand2 size={13} />
+            )}
+            {generating ? 'Generating...' : 'Generate'}
+          </button>
+        </div>
+
+        {!apiKey && (
+          <p className="text-[11px] dark:text-text-muted text-gray-400 mt-2">
+            Add an API key on any agent page to use this feature.
+          </p>
+        )}
+
+        {generatorError && (
+          <p className="text-[11px] text-red-500 mt-2">{generatorError}</p>
+        )}
+
+        {/* Custom Suite Result */}
+        {customSuite && (
+          <div className="mt-5 animate-fade-in">
+            <div className="flex items-center gap-2 mb-1">
+              <Sparkles size={13} className="text-accent" />
+              <h3 className="text-sm font-bold dark:text-text-primary text-gray-900">
+                {customSuite.title}
+              </h3>
+            </div>
+            <p className="text-xs dark:text-text-secondary text-gray-500 mb-3">
+              {customSuite.description}
+            </p>
+            <div className="flex flex-col gap-2">
+              {customSuite.agents.map((agent, index) => (
+                <div
+                  key={agent.id}
+                  className="flex items-center gap-3 p-3 rounded-lg border
+                    dark:bg-surface-input dark:border-border bg-gray-50 border-gray-200"
+                >
+                  <span className="text-[11px] font-bold text-accent w-5 flex-shrink-0">
+                    {index + 1}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-semibold dark:text-text-primary text-gray-900 truncate">
+                      {agent.id}
+                    </p>
+                    <p className="text-[11px] dark:text-text-muted text-gray-400">
+                      {agent.reason}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => navigate(`/agent/${agent.id}`)}
+                    className="flex items-center gap-1 text-[11px] font-semibold text-accent hover:opacity-80 transition-opacity flex-shrink-0"
+                  >
+                    Open
+                    <ArrowRight size={11} />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              onClick={() => { setCustomSuite(null); setGoal('') }}
+              className="mt-3 text-[11px] text-accent hover:underline"
+            >
+              ↺ Try a different goal
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Suite cards grid */}

--- a/src/pages/SuitesPage.jsx
+++ b/src/pages/SuitesPage.jsx
@@ -6,11 +6,34 @@ import SuiteWizard from '../components/SuiteWizard'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { generateCustomSuite } from '../lib/customSuiteGenerator'
 import { useApiKey } from '../lib/useApiKey'
+import ApiKeyBar from '../components/ApiKeyBar'
+
+// Map icon name string → Lucide component
+const SUITE_ICONS = {
+  Code2, BarChart3, TrendingUp, DollarSign, Palette,
+  PenLine, GraduationCap, Briefcase, HeartPulse, ShieldCheck, Gamepad2,
+}
+
+/**
+ * SuitesPage
+ *
+ * BROWSE state — shows all suite cards
+ * QUIZ state   — shows SuiteWizard for the selected suite
+ */
 export default function SuitesPage() {
   useDocumentTitle('Suites')
   const navigate = useNavigate()
-  const { apiKey, provider } = useApiKey()
+  const {
+    provider,
+    setProvider,
+    apiKey,
+    setApiKey,
+    saveForSession,
+    setSaveForSession,
+  } = useApiKey()
+
   const [activeSuite, setActiveSuite] = useState(null)
+  const [selectedModel, setSelectedModel] = useState(null)
 
   // Custom suite generator state
   const [goal, setGoal] = useState('')
@@ -77,6 +100,21 @@ export default function SuitesPage() {
           Don't see a suite for your goal? Describe it and we'll pick the best agents for you.
         </p>
 
+        {/* API Key Bar */}
+        <div className="mb-4">
+          <ApiKeyBar
+            provider={provider}
+            setProvider={setProvider}
+            apiKey={apiKey}
+            setApiKey={setApiKey}
+            saveForSession={saveForSession}
+            setSaveForSession={setSaveForSession}
+            agentProvider="any"
+            model={selectedModel}
+            setModel={setSelectedModel}
+          />
+        </div>
+
         <div className="flex gap-2">
           <input
             type="text"
@@ -104,12 +142,6 @@ export default function SuitesPage() {
             {generating ? 'Generating...' : 'Generate'}
           </button>
         </div>
-
-        {!apiKey && (
-          <p className="text-[11px] dark:text-text-muted text-gray-400 mt-2">
-            Add an API key on any agent page to use this feature.
-          </p>
-        )}
 
         {generatorError && (
           <p className="text-[11px] text-red-500 mt-2">{generatorError}</p>


### PR DESCRIPTION
## What does this PR do?
---

Adds a "Build Your Own Suite" panel to the Suites page. Users type 
their goal in plain English and get a custom ordered list of 4-6 
agents pulled from across all 11 existing suites.


## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Documentation
- [x] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅


Closes #591 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom suite generator on the Suites page.
  * Users can enter a goal, generate a tailored agent suite, and view the generated results directly in the app.
  * Generated agents now include quick navigation to each agent’s page.
  * Added provider-aware model selection for the generation flow.

* **Bug Fixes**
  * Improved handling for generation errors and loading states, with clearer feedback during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->