### PR TITLE
feat: Options in model dropdown not visible in dark mode #427 

### DIFF
--- a/src/components/CustomSelect.jsx
+++ b/src/components/CustomSelect.jsx
@@ -154,10 +154,11 @@ export default function CustomSelect({
                 onClick={() => handleSelect(val)}
                 onKeyDown={(e) => handleOptionKeyDown(e, val)}
                 className={`w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md transition-colors duration-150 text-left
+                  text-gray-700 dark:text-text-secondary
                   focus:outline-none focus:ring-2 focus:ring-accent/40
                   ${isSelected
                     ? accentItem
-                    : 'dark:text-text-secondary dark:hover:bg-surface-hover dark:hover:text-text-primary hover:bg-gray-50 hover:text-gray-900'
+                    : 'dark:hover:bg-surface-hover dark:hover:text-text-primary hover:bg-gray-50 hover:text-gray-900'
                   }`}
               >
                 {icon}


### PR DESCRIPTION
## What does this PR do?
Fixes a dark mode readability issue in the custom dropdown component.

Closes #427 

When changing the model on an agent page, dropdown options were difficult to read in dark mode because the option text could render too dark against the dark dropdown background. This PR adds explicit light and dark theme text colors to dropdown options while preserving the existing selected and hover states.

## Type of change
- [ ] New agent
- [x] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
Before: dropdown options were hard to read in dark mode.
<img width="1060" height="421" alt="image" src="https://github.com/user-attachments/assets/c0e964d0-8ae8-4c57-9a0d-abc00fa188c3" />

After: dropdown options are readable in dark mode with proper contrast.
<img width="1122" height="450" alt="image" src="https://github.com/user-attachments/assets/7866cdec-64a4-4301-b5d2-51a9d0873cf5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dropdown option styling so text colors stay consistent across states.
  * Selected options now keep their accent styling, while unselected options use hover styling more cleanly.
  * Minor formatting cleanup was applied with no change to behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->