### PR TITLE
feat: collapsible categories in Sidebar to reduce scrolling

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -4,9 +4,21 @@ import * as Icons from 'lucide-react'
 import { loadAllAgents } from '../agents/registry'
 import { useCollections } from '../lib/useCollections'
 
+const SIDEBAR_CATEGORY_STORAGE_KEY = 'sidebar-category-collapsed-state'
+
 export default function Sidebar({ open, onClose }) {
   const [sidebarSearchQuery, setSidebarSearchQuery] = useState('')
-  const [openCategories, setOpenCategories] = useState({})
+  // Stores COLLAPSED state per category (absent/false = expanded).
+  // Categories are expanded by default on first visit, since we only
+  // record an entry here when the user explicitly collapses one.
+  const [collapsedCategories, setCollapsedCategories] = useState(() => {
+    try {
+      const stored = localStorage.getItem(SIDEBAR_CATEGORY_STORAGE_KEY)
+      return stored ? JSON.parse(stored) : {}
+    } catch {
+      return {}
+    }
+  })
   const [searchExpandedCategories, setSearchExpandedCategories] = useState({})
   const [agents, setAgents] = useState([])
   const { collections } = useCollections()
@@ -22,21 +34,15 @@ export default function Sidebar({ open, onClose }) {
   }, [])
 
   useEffect(() => {
-    const currentAgentId = location.pathname.startsWith('/agent/')
-      ? location.pathname.split('/agent/')[1]
-      : null
-
-    if (currentAgentId && agents.length > 0) {
-      const activeAgent = agents.find((a) => a.id === currentAgentId)
-
-      if (activeAgent?.category) {
-        setOpenCategories((prev) => ({
-          ...prev,
-          [activeAgent.category]: true,
-        }))
-      }
+    try {
+      localStorage.setItem(
+        SIDEBAR_CATEGORY_STORAGE_KEY,
+        JSON.stringify(collapsedCategories)
+      )
+    } catch {
+      // localStorage unavailable (e.g. private browsing) — fail silently
     }
-  }, [location.pathname, agents])
+  }, [collapsedCategories])
 
   const currentAgentId = location.pathname.startsWith('/agent/')
     ? location.pathname.split('/agent/')[1]
@@ -77,7 +83,7 @@ export default function Sidebar({ open, onClose }) {
         [category]: !(prev[category] ?? true),
       }))
     } else {
-      setOpenCategories((prev) => ({
+      setCollapsedCategories((prev) => ({
         ...prev,
         [category]: !prev[category],
       }))
@@ -238,10 +244,12 @@ export default function Sidebar({ open, onClose }) {
           <div className="border-b dark:border-border border-gray-100 mb-2" />
 
           {categoryOrder.map((category) => {
+            const isActiveCategory = activeCategory === category
             const isCategoryExpanded = isSearching
               ? searchExpandedCategories[category] ?? true
-              : Boolean(openCategories[category])
-            const isActiveCategory = activeCategory === category
+              : isActiveCategory
+                ? true
+                : !collapsedCategories[category]
 
             return (
               <div key={category} className="mb-3">
@@ -282,8 +290,14 @@ export default function Sidebar({ open, onClose }) {
                   </span>
                 </button>
 
-                {isCategoryExpanded && (
-                  <div className="mt-0.5">
+                <div
+                  className={`grid transition-all duration-200 ease-in-out ${
+                    isCategoryExpanded
+                      ? 'grid-rows-[1fr] opacity-100 mt-0.5'
+                      : 'grid-rows-[0fr] opacity-0'
+                  }`}
+                >
+                  <div className="overflow-hidden">
                     {categories[category].map((agent) => {
                       const IconComponent = Icons[agent.icon] || Icons.Bot
 
@@ -319,7 +333,7 @@ export default function Sidebar({ open, onClose }) {
                       )
                     })}
                   </div>
-                )}
+                </div>
               </div>
             )
           })}


### PR DESCRIPTION
## What does this PR do?
Makes Sidebar category headers clickable to collapse/expand their agent lists, fixing issue #583 where 10+ categories with many agents each made navigation tedious on smaller screens.

`Clicking a category header toggles its agent list open/closed, with a smooth slide/fade animation instead of an abrupt show/hide.
`Collapse state is persisted per category in localStorage, so it survives page refreshes.
`All categories are expanded by default on first visit.
`Chevron icon reflects state: down when expanded, right when collapsed.
`The active agent's category always stays expanded, even if the user had previously collapsed it.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar category expand/collapse state now persists between visits.
  * Search and non-search sidebar behavior now stay consistent when browsing categories.

* **Bug Fixes**
  * Sidebar no longer loses its open/closed state after refresh.
  * Category expansion now updates more smoothly with animated transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->