### PR TITLE
feat: reset cached agent loader promise after failed initialization

### DIFF
--- a/src/agents/registry.js
+++ b/src/agents/registry.js
@@ -38,6 +38,11 @@ export function loadAllAgents() {
     Object.values(modules).map((loader) => loader())
   ).then((entries) => {
     return normalizeAgents(entries.map((mod) => mod.default));
+  })
+  .catch((error) => {
+    // Allow future calls to retry initialization after a failed load.
+    cachedAgentsPromise = null;
+    throw error;
   });
 
   return cachedAgentsPromise;


### PR DESCRIPTION
## What does this PR do?

### Summary

- Prevents failed agent initialization from permanently poisoning the lazy-loading cache.
- The changes clears the cached promise on initialization failure, allowing future calls to retry loading while preserving the existing caching behavior for successful loads.

### Implementation Details

- Added error handling to the lazy-loading initialization promise.
- Reset `cachedAgentsPromise` to `null` when the initial dynamic import fails.
- Rethrow the original error so callers continue to receive the initialization failure.
- Preserve the existing memoization behavior for successful agent initialization.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [x] Enhancement
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Additional Details

- Labels: GSSoC'2026, type:enhancement
- Closes #634 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent loading reliability by allowing failed initialization attempts to be retried on the next load.
  * Prevented a failed load from being permanently cached, so the app can recover after temporary import errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->