### PR TITLE
fix: reset loading state when switching agents

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -112,6 +112,7 @@ export default function AgentRunner({ agent }) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
     }
+    setLoading(false);
     setOutput(null);
     setStreamingOutput("");
     setIsStreaming(false);


### PR DESCRIPTION
## Description

### What does this PR do?

This PR fixes the issue where the previous agent's loading state was not reset when switching between agents.

### Changes Made

* Added `setLoading(false)` when the active agent changes.
* Reset the loading state immediately on agent switch.
* Prevented the previous agent's loading spinner from appearing on the newly selected agent.
* Preserved independent execution state for each agent.

### Issue

Closes #621

### Checklist

* [x] Code follows the project style.
* [x] Tested the changes locally.
* [x] No unrelated files were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent switching behavior so any in-progress request is fully reset when the agent changes.
  * Prevented the interface from staying stuck in a loading state after an interrupted request is aborted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->