### PR TITLE
fix: prevent concurrent localStorage writes from clobbering history/spend data

### DIFF
--- a/src/lib/useHistory.js
+++ b/src/lib/useHistory.js
@@ -1,36 +1,54 @@
 import { useState, useCallback, useEffect } from 'react';
 
+const STORAGE_KEY = 'iloveAgents_history';
+const MAX_HISTORY = 10;
+
+function loadHistory() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? JSON.parse(saved) : [];
+  } catch (error) {
+    console.error('Error loading history from localStorage:', error);
+    return [];
+  }
+}
+
+function saveHistory(history) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      console.error('LocalStorage quota exceeded. History might be truncated.');
+    } else {
+      console.error('Error saving history to localStorage:', error);
+    }
+  }
+}
+
 /**
  * Custom hook to manage agent execution history in localStorage.
  * Stores up to 10 most recent runs.
+ *
+ * Writes are computed against the freshest localStorage value (re-read at
+ * write time) rather than only the in-memory React state, and this tab's
+ * state is resynced whenever another tab writes to the same key. Without
+ * this, two tabs (or two updates racing close together) each compute a
+ * new value from their own possibly-stale in-memory copy and the last
+ * write silently overwrites the other's runs.
  */
 export const useHistory = () => {
-  const STORAGE_KEY = 'iloveAgents_history';
-  const MAX_HISTORY = 10;
+  const [history, setHistory] = useState(() => loadHistory());
 
-  // Initialize state from localStorage
-  const [history, setHistory] = useState(() => {
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      return saved ? JSON.parse(saved) : [];
-    } catch (error) {
-      console.error('Error loading history from localStorage:', error);
-      return [];
-    }
-  });
-
-  // Sync state to localStorage whenever it changes
+  // Pick up writes made by other tabs/windows to the same key.
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
-    } catch (error) {
-      if (error.name === 'QuotaExceededError') {
-        console.error('LocalStorage quota exceeded. History might be truncated.');
-      } else {
-        console.error('Error saving history to localStorage:', error);
+    const handleStorage = (e) => {
+      if (e.key === STORAGE_KEY) {
+        setHistory(loadHistory());
       }
-    }
-  }, [history]);
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   /**
    * Save a new run to history.
@@ -45,12 +63,12 @@ export const useHistory = () => {
       timestamp,
     };
 
-    setHistory((prevHistory) => {
-      // Add to beginning of array
-      const updatedHistory = [newRun, ...prevHistory];
-      // Keep only the last 10
-      return updatedHistory.slice(0, MAX_HISTORY);
-    });
+    // Merge against the current on-disk value, not stale in-memory state,
+    // so a concurrent write (another tab, or a near-simultaneous call)
+    // isn't silently discarded.
+    const updatedHistory = [newRun, ...loadHistory()].slice(0, MAX_HISTORY);
+    saveHistory(updatedHistory);
+    setHistory(updatedHistory);
   }, []);
 
   /**
@@ -58,13 +76,16 @@ export const useHistory = () => {
    * @param {string} runId - The unique ID of the run to delete.
    */
   const deleteRun = useCallback((runId) => {
-    setHistory((prevHistory) => prevHistory.filter((run) => run.id !== runId));
+    const updatedHistory = loadHistory().filter((run) => run.id !== runId);
+    saveHistory(updatedHistory);
+    setHistory(updatedHistory);
   }, []);
 
   /**
    * Clear all history from state and localStorage.
    */
   const clearHistory = useCallback(() => {
+    saveHistory([]);
     setHistory([]);
   }, []);
 

--- a/src/lib/useSessionSpend.js
+++ b/src/lib/useSessionSpend.js
@@ -37,34 +37,36 @@ export function useSessionSpend() {
   }, [])
 
   const addRun = useCallback(({ model, inputTokens, outputTokens, inputCost, outputCost }) => {
-    setSessionData((prev) => {
-      let inputC = inputCost
-      let outputC = outputCost
+    let inputC = inputCost
+    let outputC = outputCost
 
-      if (inputC == null && inputTokens != null && model) {
-        inputC = estimateInputCost(model, inputTokens) || 0
-      }
-      if (outputC == null && outputTokens != null && model) {
-        outputC = estimateOutputCost(model, outputTokens) || 0
-      }
+    if (inputC == null && inputTokens != null && model) {
+      inputC = estimateInputCost(model, inputTokens) || 0
+    }
+    if (outputC == null && outputTokens != null && model) {
+      outputC = estimateOutputCost(model, outputTokens) || 0
+    }
 
-      const runCost = (inputC || 0) + (outputC || 0)
-      const run = {
-        model,
-        inputTokens: inputTokens || 0,
-        outputTokens: outputTokens || 0,
-        inputCost: inputC || 0,
-        outputCost: outputC || 0,
-        totalCost: runCost,
-        timestamp: Date.now(),
-      }
+    const runCost = (inputC || 0) + (outputC || 0)
+    const run = {
+      model,
+      inputTokens: inputTokens || 0,
+      outputTokens: outputTokens || 0,
+      inputCost: inputC || 0,
+      outputCost: outputC || 0,
+      totalCost: runCost,
+      timestamp: Date.now(),
+    }
 
-      const runs = [run, ...prev.runs].slice(0, MAX_RUNS)
-      const totalSpend = runs.reduce((sum, r) => sum + r.totalCost, 0)
-      const newData = { runs, totalSpend }
-      saveSession(newData)
-      return newData
-    })
+    // Merge against the current on-disk value, not stale in-memory state,
+    // so a concurrent write (another tab, or two runs completing close
+    // together) isn't silently discarded by the last write winning.
+    const prev = loadSession()
+    const runs = [run, ...prev.runs].slice(0, MAX_RUNS)
+    const totalSpend = runs.reduce((sum, r) => sum + r.totalCost, 0)
+    const newData = { runs, totalSpend }
+    saveSession(newData)
+    setSessionData(newData)
   }, [])
 
   const clearSession = useCallback(() => {


### PR DESCRIPTION
## Summary

Closes #646

The issue's proposed fix targets a Python `asyncio`/shared-dict race condition, but this repo is a pure JS/React frontend (no Python, no backend agent pipeline). I verified this and left a comment on the issue explaining the real, equivalent bug found in this codebase.

Both `src/lib/useHistory.js` and `src/lib/useSessionSpend.js` persist arrays built from in-memory React state to localStorage. If two tabs are open, or two writes happen close together, each writer can compute its update from a stale in-memory copy, and the last write silently overwrites the other's entries — losing run history or spend data, the same class of bug the issue describes (concurrent writers corrupting shared state), just via localStorage instead of a Python dict.

## Changes

- `useHistory.js`: `saveRun`, `deleteRun`, and `clearHistory` now read the current on-disk localStorage value fresh at write time and merge against that, instead of trusting in-memory state that may be stale. Added the missing `storage` event listener so a tab resyncs when another tab writes to the same key.
- `useSessionSpend.js`: `addRun` now reads fresh from localStorage before merging in the new run, instead of relying only on the React `prev` argument (which already had the `storage` listener for reads, but not this write-time fix).

## Verification

- `npm run build` passes with no errors.
- Manually verified sequential/rapid writes to history no longer drop earlier entries (previously reproducible with stale in-memory state).
- Grepped for the broken registry import pattern the CI build check looks for — none introduced.

No test runner is configured in this repo (package.json only has `dev`/`build`/`preview`), so verification here is build-pass + manual logic check, matching what CI actually runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run history saving so recent changes are less likely to be lost.
  * Kept history more consistent when the app is open in multiple tabs.
  * Made session spend totals and run records update more reliably when actions happen close together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->