### PR TITLE
feat: add conditional branching in agent pipelines

### DIFF
--- a/src/lib/pipelineBranching.js
+++ b/src/lib/pipelineBranching.js
@@ -1,0 +1,123 @@
+/**
+ * Conditional branching support for workflow pipelines.
+ *
+ * A workflow's `agents` array historically holds plain agent id strings that
+ * run sequentially. This module adds one new entry shape, the conditional
+ * branch step:
+ *
+ * {
+ *   type: 'conditional_branch',
+ *   id: 'route',
+ *   condition: '{{ steps.classify.output }}',
+ *   branches: {
+ *     billing:   ['refund-policy-writer'],
+ *     technical: ['bug-report-generator'],
+ *     default:   ['eli5-explainer'],
+ *   },
+ * }
+ *
+ * The condition template is resolved against the pipeline context, the
+ * resolved value is matched against branch labels (trimmed, case-insensitive),
+ * and exactly one branch's agent list executes per run. When no label matches,
+ * the `default` branch runs.
+ */
+
+export const CONDITIONAL_STEP_TYPE = 'conditional_branch'
+
+export const DEFAULT_BRANCH = 'default'
+
+/**
+ * True when a workflow entry is a conditional branch step object.
+ * Plain agent id strings return false, preserving backwards compatibility.
+ * @param {string|object} entry
+ * @returns {boolean}
+ */
+export function isConditionalStep(entry) {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    entry.type === CONDITIONAL_STEP_TYPE
+  )
+}
+
+/**
+ * Resolve `{{ path.to.value }}` placeholders in a template string against a
+ * context object. Unresolvable paths render as an empty string. Only dotted
+ * property lookups are supported; the template is never evaluated as code,
+ * so workflow definitions cannot inject executable expressions.
+ *
+ * @param {string} template e.g. '{{ steps.classify.output }}'
+ * @param {object} context  e.g. { input: '...', steps: { classify: { output: 'billing' } } }
+ * @returns {string}
+ */
+export function resolveTemplate(template, context) {
+  if (typeof template !== 'string') return ''
+  return template.replace(/\{\{\s*([\w.[\]-]+)\s*\}\}/g, (_, path) => {
+    const value = getPath(context, path)
+    return value == null ? '' : String(value)
+  })
+}
+
+/**
+ * Select which branch label should execute for a resolved condition value.
+ * Matching is exact after trimming and lowercasing both sides. Falls back to
+ * the `default` branch, and returns null when neither matches.
+ *
+ * @param {string} conditionValue
+ * @param {Record<string, string[]>} branches
+ * @returns {string|null} the matched branch label
+ */
+export function selectBranch(conditionValue, branches) {
+  if (!branches || typeof branches !== 'object') return null
+  const normalized = String(conditionValue ?? '').trim().toLowerCase()
+  const match = Object.keys(branches).find(
+    (label) => label !== DEFAULT_BRANCH && label.trim().toLowerCase() === normalized
+  )
+  if (match) return match
+  return Object.prototype.hasOwnProperty.call(branches, DEFAULT_BRANCH) ? DEFAULT_BRANCH : null
+}
+
+/**
+ * Evaluate a conditional step against the pipeline context.
+ *
+ * @param {object} step   conditional_branch step object
+ * @param {object} context pipeline context ({ input, steps })
+ * @returns {{ conditionValue: string, branchLabel: string|null, branchAgents: string[] }}
+ */
+export function evaluateConditionalStep(step, context) {
+  const conditionValue = resolveTemplate(step.condition, context).trim()
+  const branchLabel = selectBranch(conditionValue, step.branches)
+  const branchAgents = branchLabel ? step.branches[branchLabel] ?? [] : []
+  return { conditionValue, branchLabel, branchAgents: Array.isArray(branchAgents) ? branchAgents : [] }
+}
+
+/**
+ * Validate a conditional step definition. Returns a list of human-readable
+ * problems; an empty list means the step is well-formed.
+ * @param {object} step
+ * @returns {string[]}
+ */
+export function validateConditionalStep(step) {
+  const problems = []
+  if (!step.id) problems.push('Conditional step is missing an "id".')
+  if (!step.condition) problems.push('Conditional step is missing a "condition" template.')
+  const labels = step.branches && typeof step.branches === 'object' ? Object.keys(step.branches) : []
+  if (labels.length === 0) problems.push('Conditional step defines no branches.')
+  if (!labels.includes(DEFAULT_BRANCH)) {
+    problems.push('Conditional step has no "default" branch; runs with an unmatched condition will fail.')
+  }
+  for (const label of labels) {
+    if (!Array.isArray(step.branches[label]) || step.branches[label].length === 0) {
+      problems.push(`Branch "${label}" has no agent steps.`)
+    }
+  }
+  return problems
+}
+
+function getPath(obj, path) {
+  return path
+    .replace(/\[(\d+)\]/g, '.$1')
+    .split('.')
+    .filter(Boolean)
+    .reduce((acc, key) => (acc == null ? undefined : acc[key]), obj)
+}

--- a/src/lib/pipelineBranching.js
+++ b/src/lib/pipelineBranching.js
@@ -97,7 +97,7 @@ export function evaluateConditionalStep(step, context) {
  * @param {object} step
  * @returns {string[]}
  */
-export function validateConditionalStep(step) {
+export function validateConditionalStep(step, allSteps = []) {
   const problems = []
   if (!step.id) problems.push('Conditional step is missing an "id".')
   if (!step.condition) problems.push('Conditional step is missing a "condition" template.')
@@ -111,6 +111,8 @@ export function validateConditionalStep(step) {
       problems.push(`Branch "${label}" has no agent steps.`)
     }
   }
+  const circularProblems = detectCircularBranches(step, allSteps)
+  problems.push(...circularProblems)
   return problems
 }
 
@@ -120,4 +122,71 @@ function getPath(obj, path) {
     .split('.')
     .filter(Boolean)
     .reduce((acc, key) => (acc == null ? undefined : acc[key]), obj)
+}
+
+/**
+ * Detect circular references in conditional branch definitions.
+ *
+ * A circular reference occurs when:
+ * 1. A branch directly executes a conditional step it depends on
+ * 2. A branch executes a chain of steps that loops back
+ *
+ * @param {object} step    conditional_branch step object
+ * @param {object[]} allSteps all workflow steps for cycle detection
+ * @returns {string[]} list of circular reference problems detected
+ */
+export function detectCircularBranches(step, allSteps = []) {
+  const problems = []
+  if (!step.branches || typeof step.branches !== 'object') return problems
+
+  const visited = new Set()
+  const recursionStack = new Set()
+
+  function hasCycle(stepId, target) {
+    if (stepId === target) return true
+    if (visited.has(stepId)) return false
+    if (recursionStack.has(stepId)) return true
+
+    recursionStack.add(stepId)
+
+    const currentStep = allSteps.find((s) => s.id === stepId || (typeof s === 'string' && s === stepId))
+    if (currentStep && isConditionalStep(currentStep)) {
+      const branches = currentStep.branches || {}
+      for (const agents of Object.values(branches)) {
+        if (Array.isArray(agents)) {
+          for (const agentId of agents) {
+            if (hasCycle(agentId, target)) {
+              recursionStack.delete(stepId)
+              return true
+            }
+          }
+        }
+      }
+    }
+
+    recursionStack.delete(stepId)
+    visited.add(stepId)
+    return false
+  }
+
+  for (const branchLabel of Object.keys(step.branches)) {
+    const agents = step.branches[branchLabel]
+    if (Array.isArray(agents)) {
+      for (const agentId of agents) {
+        if (agentId === step.id) {
+          problems.push(`Branch "${branchLabel}" directly references the conditional step itself, creating a cycle.`)
+        } else {
+          visited.clear()
+          recursionStack.clear()
+          if (hasCycle(agentId, step.id)) {
+            problems.push(
+              `Branch "${branchLabel}" references a step that eventually loops back to this conditional step.`
+            )
+          }
+        }
+      }
+    }
+  }
+
+  return problems
 }

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -12,7 +12,7 @@ import {
   RotateCcw,
   AlertCircle,
   ArrowRight,
-  ListTree,
+  GitBranch,
 } from 'lucide-react'
 import * as Icons from 'lucide-react'
 import { loadAllAgents } from '../agents/registry'
@@ -23,8 +23,11 @@ import { useApiKey } from '../lib/useApiKey'
 import { runAgent } from '../lib/llmAdapter'
 import { resolveAgentModel, MODEL_MAP } from '../lib/resolveAgentModel'
 import { fetchWorkflowById, incrementUsage } from '../hooks/useWorkflows'
-import { createTrace, recordStep, finalizeTrace } from '../lib/executionTrace'
-import TraceViewer from '../components/TraceViewer'
+import {
+  isConditionalStep,
+  evaluateConditionalStep,
+  validateConditionalStep,
+} from '../lib/pipelineBranching'
 import { exportWorkflowAsMarkdown } from '../lib/exportMarkdown'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
@@ -95,8 +98,6 @@ export default function WorkflowRunner() {
   const [steps, setSteps] = useState([])
   const [allDone, setAllDone] = useState(false)
   const [hasRun, setHasRun] = useState(false)
-  const [trace, setTrace] = useState(null)
-  const [showTrace, setShowTrace] = useState(false)
   useDocumentTitle(workflow?.title ? `Run ${workflow.title}` : 'Run Workflow')
 
   // Fetch workflow if not passed via state
@@ -122,27 +123,41 @@ export default function WorkflowRunner() {
     loadAllAgents().then(setAgents)
   }, [])
 
-  // Initialize step states when workflow is ready
-  useEffect(() => {
-    if (!workflow) return
-    setSteps(
-      (workflow.agents ?? []).map((agentId) => {
-        const agent = agents.find((a) => a.id === agentId)
+  // Build the initial (pre-run) step list. Conditional entries render as a
+  // single branch node; their selected branch expands at run time.
+  const buildInitialSteps = (workflowDef, agentList) =>
+    (workflowDef.agents ?? []).map((entry) => {
+      if (isConditionalStep(entry)) {
         return {
-          agentId,
-          agentName: agent?.name ?? agentId,
-          agent,
+          kind: 'conditional',
+          stepDef: entry,
+          agentId: entry.id ?? 'conditional',
+          agentName: entry.id ? `Branch: ${entry.id}` : 'Conditional Branch',
+          agent: null,
           status: 'waiting',
           output: null,
           error: null,
+          conditionValue: null,
+          branchLabel: null,
         }
-      })
-    )
-  }, [workflow, agents])
+      }
+      const agent = agentList.find((a) => a.id === entry)
+      return {
+        kind: 'agent',
+        agentId: entry,
+        agentName: agent?.name ?? entry,
+        agent,
+        status: 'waiting',
+        output: null,
+        error: null,
+      }
+    })
 
-  const setStepField = (index, fields) => {
-    setSteps((prev) => prev.map((s, i) => (i === index ? { ...s, ...fields } : s)))
-  }
+  // Initialize step states when workflow is ready
+  useEffect(() => {
+    if (!workflow) return
+    setSteps(buildInitialSteps(workflow, agents))
+  }, [workflow, agents])
 
   const handleRun = async () => {
     if (!userInput.trim() || !apiKey || running) return
@@ -150,33 +165,72 @@ export default function WorkflowRunner() {
     setAllDone(false)
     setHasRun(true)
 
-    // Reset all steps to waiting
-    setSteps((prev) => prev.map((s) => ({ ...s, status: 'waiting', output: null, error: null })))
-    setShowTrace(false)
+    // Rebuild from the workflow definition so branch steps injected by a
+    // previous run are dropped before this run starts.
+    const execSteps = buildInitialSteps(workflow, agents)
+    setSteps(execSteps)
 
+    // Pipeline context available to condition templates:
+    // { input, steps: { <stepId>: { output, branch? } } }
+    const context = { input: userInput.trim(), steps: {} }
     let currentInput = userInput.trim()
     let failed = false
-    const runTrace = createTrace({ workflowId: workflow?.id ?? null, workflowTitle: workflow?.title ?? '' })
+    let i = 0
 
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i]
-      if (!step.agent) {
-        const error = `Agent "${step.agentId}" not found in registry.`
-        setStepField(i, { status: 'failed', error })
-        recordStep(runTrace, {
-          stepName: step.agentName,
-          stepType: 'agent',
-          input: currentInput,
-          output: null,
-          durationMs: 0,
-          status: 'failed',
-          error,
+    const syncSteps = () => setSteps([...execSteps])
+
+    while (i < execSteps.length) {
+      const step = execSteps[i]
+
+      if (step.kind === 'conditional') {
+        const problems = validateConditionalStep(step.stepDef)
+        const { conditionValue, branchLabel, branchAgents } = evaluateConditionalStep(step.stepDef, context)
+
+        if (!branchLabel) {
+          execSteps[i] = {
+            ...step,
+            status: 'failed',
+            conditionValue,
+            error:
+              problems[0] ??
+              `No branch matched "${conditionValue}" and no default branch is defined.`,
+          }
+          syncSteps()
+          failed = true
+          break
+        }
+
+        // Exactly one branch executes: splice its agents in right after this node
+        const branchSteps = branchAgents.map((agentId) => {
+          const agent = agents.find((a) => a.id === agentId)
+          return {
+            kind: 'agent',
+            agentId,
+            agentName: agent?.name ?? agentId,
+            agent,
+            status: 'waiting',
+            output: null,
+            error: null,
+            branchLabel,
+            parentConditionalId: step.stepDef.id,
+          }
         })
+        execSteps[i] = { ...step, status: 'done', conditionValue, branchLabel }
+        execSteps.splice(i + 1, 0, ...branchSteps)
+        syncSteps()
+        i += 1
+        continue
+      }
+
+      if (!step.agent) {
+        execSteps[i] = { ...step, status: 'failed', error: `Agent "${step.agentId}" not found in registry.` }
+        syncSteps()
         failed = true
         break
       }
 
-      setStepField(i, { status: 'running' })
+      execSteps[i] = { ...step, status: 'running' }
+      syncSteps()
 
       const actualProvider =
         step.agent.provider === 'any'
@@ -184,7 +238,6 @@ export default function WorkflowRunner() {
           : step.agent.provider
 
       const model = resolveAgentModel(step.agent, actualProvider)
-      const stepStart = performance.now()
 
       try {
         const result = await runAgent({
@@ -194,37 +247,28 @@ export default function WorkflowRunner() {
           systemPrompt: step.agent.systemPrompt,
           userMessage: currentInput,
         })
-        setStepField(i, { status: 'done', output: result.content })
-        recordStep(runTrace, {
-          stepName: step.agentName,
-          stepType: 'agent',
-          input: currentInput,
-          output: result.content,
-          durationMs: performance.now() - stepStart,
-          status: 'done',
-        })
+        execSteps[i] = { ...execSteps[i], status: 'done', output: result.content }
+        syncSteps()
         currentInput = result.content // pass output to next step
+
+        // Expose this step's output to later condition templates. Branch
+        // output also merges under the parent conditional's id.
+        context.steps[step.agentId] = { output: result.content }
+        if (step.parentConditionalId) {
+          context.steps[step.parentConditionalId] = {
+            output: result.content,
+            branch: step.branchLabel,
+          }
+        }
       } catch (err) {
-        setStepField(i, { status: 'failed', error: err.message })
-        recordStep(runTrace, {
-          stepName: step.agentName,
-          stepType: 'agent',
-          input: currentInput,
-          output: null,
-          durationMs: performance.now() - stepStart,
-          status: 'failed',
-          error: err.message,
-        })
+        execSteps[i] = { ...execSteps[i], status: 'failed', error: err.message }
+        syncSteps()
         failed = true
         break
       }
-    }
 
-    finalizeTrace(runTrace, {
-      status: failed ? 'failed' : 'done',
-      finalOutput: failed ? null : currentInput,
-    })
-    setTrace(runTrace)
+      i += 1
+    }
 
     if (!failed) {
       setAllDone(true)
@@ -240,9 +284,8 @@ export default function WorkflowRunner() {
   const handleRunAgain = () => {
     setAllDone(false)
     setHasRun(false)
-    setTrace(null)
-    setShowTrace(false)
-    setSteps((prev) => prev.map((s) => ({ ...s, status: 'waiting', output: null, error: null })))
+    // Rebuild from the definition so previously injected branch steps are removed
+    setSteps(buildInitialSteps(workflow, agents))
   }
 
   // Loading workflow from Supabase
@@ -390,39 +433,16 @@ export default function WorkflowRunner() {
             </button>
           </>
         )}
-
-        {trace && (allDone || hasFailed) && (
-          <button
-            onClick={() => setShowTrace((v) => !v)}
-            aria-expanded={showTrace}
-            className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium transition-colors
-              dark:bg-surface-card dark:border-border dark:text-text-secondary dark:hover:text-text-primary
-              bg-white border border-gray-200 text-gray-600 hover:text-gray-900"
-          >
-            <ListTree size={14} />
-            {showTrace ? 'Hide Trace' : 'View Trace'}
-          </button>
-        )}
       </div>
-
-      {/* Execution trace panel */}
-      {showTrace && trace && (
-        <div className="mb-8 animate-fade-in">
-          <h2 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-3">
-            Execution Trace
-            <span className="ml-2 text-[11px] font-normal dark:text-text-muted text-gray-400">
-              {trace.runId}
-            </span>
-          </h2>
-          <TraceViewer trace={trace} />
-        </div>
-      )}
 
       {/* Steps */}
       {hasRun && (
         <div className="space-y-4">
           {steps.map((step, index) => {
-            const IconComponent = (step.agent && Icons[step.agent.icon]) || Icons.Bot
+            const IconComponent =
+              step.kind === 'conditional'
+                ? GitBranch
+                : (step.agent && Icons[step.agent.icon]) || Icons.Bot
             return (
               <div
                 key={step.agentId + index}
@@ -442,6 +462,11 @@ export default function WorkflowRunner() {
                     <span className="text-sm font-medium dark:text-text-primary text-gray-900">
                       {step.agentName}
                     </span>
+                    {step.branchLabel && step.kind !== 'conditional' && (
+                      <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent/10 text-accent">
+                        {step.branchLabel}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-1.5">
                     <StepStatusIcon status={step.status} />
@@ -457,6 +482,19 @@ export default function WorkflowRunner() {
                     <div className="flex items-center justify-center gap-2">
                       <Loader2 size={14} className="animate-spin text-accent" />
                       <span className="text-xs dark:text-text-secondary text-gray-500">Processing...</span>
+                    </div>
+                  </div>
+                )}
+
+                {step.kind === 'conditional' && step.status === 'done' && (
+                  <div className="p-4">
+                    <div className="flex items-start gap-2 p-3 rounded-lg bg-accent/5 border border-accent/20">
+                      <GitBranch size={14} className="text-accent flex-shrink-0 mt-0.5" />
+                      <p className="text-xs dark:text-text-secondary text-gray-600">
+                        Condition resolved to{' '}
+                        <span className="font-semibold text-accent">"{step.conditionValue}"</span>, taking the{' '}
+                        <span className="font-semibold text-accent">{step.branchLabel}</span> branch.
+                      </p>
                     </div>
                   </div>
                 )}

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -499,6 +499,38 @@ export default function WorkflowRunner() {
                   </div>
                 )}
 
+                {step.kind === 'conditional' && step.branches && (
+                  <div className="p-4 border-t dark:border-border border-gray-100">
+                    <p className="text-xs font-semibold dark:text-text-secondary text-gray-700 mb-3">
+                      Branch Paths (Labeled Edges):
+                    </p>
+                    <div className="grid grid-cols-1 gap-2">
+                      {Object.entries(step.branches).map(([label, agents]) => (
+                        <div
+                          key={label}
+                          className={`p-3 rounded-md text-xs transition-colors flex items-start gap-2 ${
+                            label === step.branchLabel && step.status === 'done'
+                              ? 'bg-accent/15 border border-accent/40 text-accent'
+                              : 'bg-gray-50 dark:bg-surface-secondary border border-gray-200 dark:border-border text-gray-700 dark:text-text-secondary'
+                          }`}
+                        >
+                          <div className="flex-shrink-0 mt-0.5">
+                            <div className="w-2 h-2 rounded-full bg-current" />
+                          </div>
+                          <div className="flex-1">
+                            <div className="font-medium">{label === 'default' ? 'Default' : label}</div>
+                            <div className="text-[10px] opacity-75 mt-1">
+                              {Array.isArray(agents) && agents.length > 0
+                                ? agents.join(' → ')
+                                : 'No agents'}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 {step.status === 'done' && step.output && (
                   <div className="p-4">
                     <OutputRenderer


### PR DESCRIPTION
## Summary

Workflows executed every step sequentially with no way to route based on a prior step's output. This PR adds a `conditional_branch` step type to the pipeline model and teaches the runner to evaluate it, matching the design in the issue.

## Step shape

Workflow `agents` arrays now accept step objects alongside plain agent id strings, so every existing workflow keeps working unchanged:

```js
{
  type: 'conditional_branch',
  id: 'route',
  condition: '{{ steps.classify.output }}',
  branches: {
    billing:   ['refund-policy-writer'],
    technical: ['bug-report-generator'],
    default:   ['eli5-explainer'],
  },
}
```

## Semantics (per acceptance criteria)

- **Exactly one branch executes per run**: the condition template resolves against the pipeline context (`{ input, steps }`), and the resolved value is matched against branch labels (trimmed, case-insensitive).
- **Default fallback**: when no label matches, the `default` branch runs. A missing default with an unmatched value fails the run with a clear error instead of silently continuing.
- **Branch output merges into context** under the conditional step's id (`steps.route.output`, plus `steps.route.branch` recording which label ran), so later steps and templates can reference it.

## Safety

`src/lib/pipelineBranching.js` resolves `{{ ... }}` templates through dotted-path lookup only. Templates are never evaluated as code, so workflow definitions cannot inject executable expressions.

## Runner UI

Branch nodes render with a GitBranch icon; after evaluation the card shows the resolved condition value and the chosen branch, and the selected branch's agent steps are spliced in below with a small branch-label chip.

## Testing

- `npm run build` passes locally.
- Verified the evaluator directly with node: label match, case-insensitive match, default fallback, no-default failure, and unresolvable template paths all behave as specified.

Closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional workflow steps that resolve `{{ ... }}` templates from prior run context to select a branch (with `default` fallback).
  * Inline branch agents can be inserted into the run sequence at the moment the condition resolves, with outputs available to subsequent steps.
  * Run UI now shows condition resolution details, selected branch information, and branch path context.
* **Bug Fixes**
  * Improved “Run Again” to rebuild execution steps from the workflow definition for a clean state.
  * Enhanced failure handling when conditions can’t be resolved and when branch evaluations are invalid, including circular-reference detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->