### PR TITLE
feat: add agent marketplace for sharing and importing community agents

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import SuitesPage from './pages/SuitesPage'
 import CollectionsPage from './pages/CollectionsPage'
 import CollectionDetailPage from './pages/CollectionDetailPage'
 import SchedulerPage from './pages/SchedulerPage'
+import MarketplacePage from './pages/MarketplacePage'
 import ErrorBoundary from './components/ErrorBoundary'
 import Privacy from './pages/Privacy'
 
@@ -63,6 +64,8 @@ export default function App() {
             <Route path="/collections/:id" element={<CollectionDetailPage />} />
 
             <Route path="/scheduler" element={<SchedulerPage />} />
+
+            <Route path="/marketplace" element={<MarketplacePage />} />
 
             <Route path="/workflows" element={<WorkflowLibrary />} />
             <Route path="/workflows/build" element={<WorkflowBuilder />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -241,6 +241,22 @@ export default function Sidebar({ open, onClose }) {
             <span className="truncate">Scheduler</span>
           </NavLink>
 
+          <NavLink
+            to="/marketplace"
+            onClick={onClose}
+            className={({ isActive }) =>
+              `flex items-center gap-2.5 px-2.5 py-2 rounded-md text-[13px] font-medium transition-colors mb-0.5
+              ${
+                isActive
+                  ? 'bg-accent/10 text-accent dark:text-accent'
+                  : 'dark:text-text-secondary dark:hover:text-text-primary dark:hover:bg-surface-hover text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+              }`
+            }
+          >
+            <Icons.Store size={15} className="flex-shrink-0" />
+            <span className="truncate">Marketplace</span>
+          </NavLink>
+
           <div className="border-b dark:border-border border-gray-100 mb-2" />
 
           {categoryOrder.map((category) => {

--- a/src/lib/marketplace.js
+++ b/src/lib/marketplace.js
@@ -1,0 +1,216 @@
+/**
+ * Agent Marketplace storage layer.
+ *
+ * Published agents, import counts, and ratings live in localStorage so the
+ * marketplace works fully client side, matching how favorites and collections
+ * already persist in this app. Every function is storage-failure safe: a
+ * blocked or full localStorage degrades to an empty marketplace instead of
+ * throwing.
+ */
+
+const LISTINGS_KEY = 'ila_marketplace_listings'
+const DRAFTS_KEY = 'ila_marketplace_drafts'
+const VOTES_KEY = 'ila_marketplace_votes'
+
+export const MARKETPLACE_CATEGORIES = [
+  'Data Processing',
+  'Content Generation',
+  'Research',
+]
+
+// Config keys that must never be published as-is
+const CREDENTIAL_KEY_PATTERN = /(api[_-]?key|token|secret|password|credential|auth)/i
+
+/**
+ * Deep-copy an agent config, replacing the value of any credential-like field
+ * with an explicit placeholder. Returns { config, sanitizedFields } where
+ * sanitizedFields lists the dotted paths that were replaced.
+ * @param {object} config
+ * @returns {{ config: object, sanitizedFields: string[] }}
+ */
+export function sanitizeAgentConfig(config) {
+  const sanitizedFields = []
+
+  const walk = (value, path) => {
+    if (Array.isArray(value)) return value.map((v, i) => walk(v, `${path}[${i}]`))
+    if (value && typeof value === 'object') {
+      const out = {}
+      for (const [key, v] of Object.entries(value)) {
+        const childPath = path ? `${path}.${key}` : key
+        if (CREDENTIAL_KEY_PATTERN.test(key) && typeof v === 'string' && v !== '') {
+          out[key] = `YOUR_${key.replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}_HERE`
+          sanitizedFields.push(childPath)
+        } else {
+          out[key] = walk(v, childPath)
+        }
+      }
+      return out
+    }
+    return value
+  }
+
+  return { config: walk(config ?? {}, ''), sanitizedFields }
+}
+
+/**
+ * Publish an agent to the marketplace. The config is always sanitized before
+ * it is stored.
+ * @param {{ name: string, description: string, tags: string[], category: string, readme?: string, author?: string, config: object }} entry
+ * @returns {object} the stored listing
+ */
+export function publishAgent(entry) {
+  const { config, sanitizedFields } = sanitizeAgentConfig(entry.config)
+  const listing = {
+    id: `mkt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    name: String(entry.name ?? '').trim(),
+    description: String(entry.description ?? '').trim(),
+    tags: (entry.tags ?? []).map((t) => String(t).trim()).filter(Boolean).slice(0, 8),
+    category: MARKETPLACE_CATEGORIES.includes(entry.category) ? entry.category : MARKETPLACE_CATEGORIES[0],
+    readme: entry.readme ? String(entry.readme) : '',
+    author: String(entry.author ?? 'Anonymous').trim() || 'Anonymous',
+    config,
+    sanitizedFields,
+    importCount: 0,
+    ratingTotal: 0,
+    ratingCount: 0,
+    publishedAt: new Date().toISOString(),
+  }
+  const listings = loadListings()
+  listings.unshift(listing)
+  saveJson(LISTINGS_KEY, listings)
+  return listing
+}
+
+/**
+ * All published listings, newest first.
+ * @returns {Array<object>}
+ */
+export function loadListings() {
+  return loadJson(LISTINGS_KEY, [])
+}
+
+/**
+ * Import a listing into the local workspace as a draft. The draft keeps the
+ * sanitized config and flags which credential fields still need real values,
+ * so it cannot run until the user fills them in.
+ * @param {string} listingId
+ * @returns {object|null} the created draft, or null when the listing is gone
+ */
+export function importAgent(listingId) {
+  const listings = loadListings()
+  const listing = listings.find((l) => l.id === listingId)
+  if (!listing) return null
+
+  const draft = {
+    id: `draft_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    sourceListingId: listing.id,
+    name: `${listing.name} (imported)`,
+    description: listing.description,
+    tags: [...listing.tags],
+    config: JSON.parse(JSON.stringify(listing.config)),
+    pendingCredentialFields: [...listing.sanitizedFields],
+    readyToRun: listing.sanitizedFields.length === 0,
+    importedAt: new Date().toISOString(),
+  }
+
+  const drafts = loadJson(DRAFTS_KEY, [])
+  drafts.unshift(draft)
+  saveJson(DRAFTS_KEY, drafts)
+
+  listing.importCount = (listing.importCount ?? 0) + 1
+  saveJson(LISTINGS_KEY, listings)
+
+  return draft
+}
+
+/**
+ * Imported drafts, newest first.
+ * @returns {Array<object>}
+ */
+export function loadDrafts() {
+  return loadJson(DRAFTS_KEY, [])
+}
+
+/**
+ * Rate a listing 1 to 5 stars. One vote per user per agent: re-rating
+ * replaces the previous vote instead of adding a second one.
+ * @param {string} listingId
+ * @param {number} stars 1..5
+ * @returns {{ average: number, count: number }|null}
+ */
+export function rateAgent(listingId, stars) {
+  const value = Math.min(5, Math.max(1, Math.round(stars)))
+  const listings = loadListings()
+  const listing = listings.find((l) => l.id === listingId)
+  if (!listing) return null
+
+  const votes = loadJson(VOTES_KEY, {})
+  const previous = votes[listingId]
+
+  if (previous) {
+    listing.ratingTotal = listing.ratingTotal - previous + value
+  } else {
+    listing.ratingTotal = (listing.ratingTotal ?? 0) + value
+    listing.ratingCount = (listing.ratingCount ?? 0) + 1
+  }
+  votes[listingId] = value
+
+  saveJson(LISTINGS_KEY, listings)
+  saveJson(VOTES_KEY, votes)
+  return { average: getAverageRating(listing), count: listing.ratingCount }
+}
+
+/**
+ * The current user's vote for a listing, or null.
+ * @param {string} listingId
+ * @returns {number|null}
+ */
+export function getUserVote(listingId) {
+  const votes = loadJson(VOTES_KEY, {})
+  return votes[listingId] ?? null
+}
+
+/**
+ * Average rating rounded to one decimal, 0 when unrated.
+ * @param {object} listing
+ * @returns {number}
+ */
+export function getAverageRating(listing) {
+  if (!listing?.ratingCount) return 0
+  return Math.round((listing.ratingTotal / listing.ratingCount) * 10) / 10
+}
+
+/**
+ * Filter listings by free-text search (name and tags) and category.
+ * @param {Array<object>} listings
+ * @param {{ search?: string, category?: string }} filters
+ * @returns {Array<object>}
+ */
+export function filterListings(listings, { search = '', category = '' } = {}) {
+  const q = search.trim().toLowerCase()
+  return listings.filter((l) => {
+    if (category && l.category !== category) return false
+    if (!q) return true
+    return (
+      l.name.toLowerCase().includes(q) ||
+      l.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  })
+}
+
+function loadJson(key, fallback) {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(key) ?? 'null')
+    return parsed ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+function saveJson(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Storage unavailable or full; the UI keeps its in-memory state
+  }
+}

--- a/src/pages/MarketplacePage.jsx
+++ b/src/pages/MarketplacePage.jsx
@@ -1,0 +1,396 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Store,
+  Search,
+  Star,
+  Download,
+  UploadCloud,
+  X,
+  Check,
+  ShieldCheck,
+  Tag,
+} from 'lucide-react'
+import { loadAllAgents } from '../agents/registry'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+import {
+  MARKETPLACE_CATEGORIES,
+  loadListings,
+  publishAgent,
+  importAgent,
+  rateAgent,
+  getUserVote,
+  getAverageRating,
+  filterListings,
+} from '../lib/marketplace'
+
+function StarRating({ listing, onRate }) {
+  const [hover, setHover] = useState(0)
+  const userVote = getUserVote(listing.id)
+  const average = getAverageRating(listing)
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="flex" role="radiogroup" aria-label={`Rate ${listing.name}`}>
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            role="radio"
+            aria-checked={userVote === star}
+            aria-label={`${star} star${star > 1 ? 's' : ''}`}
+            onClick={() => onRate(listing.id, star)}
+            onMouseEnter={() => setHover(star)}
+            onMouseLeave={() => setHover(0)}
+            className="p-0.5"
+          >
+            <Star
+              size={13}
+              className={
+                star <= (hover || userVote || Math.round(average))
+                  ? 'text-amber-400 fill-amber-400'
+                  : 'dark:text-text-muted text-gray-300'
+              }
+            />
+          </button>
+        ))}
+      </div>
+      <span className="text-[11px] dark:text-text-muted text-gray-400">
+        {average > 0 ? `${average} (${listing.ratingCount})` : 'No ratings'}
+      </span>
+    </div>
+  )
+}
+
+function PublishModal({ agents, onClose, onPublished }) {
+  const [agentId, setAgentId] = useState('')
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [tags, setTags] = useState('')
+  const [category, setCategory] = useState(MARKETPLACE_CATEGORIES[0])
+  const [readme, setReadme] = useState('')
+  const [author, setAuthor] = useState('')
+
+  const selected = agents.find((a) => a.id === agentId)
+  const canPublish = agentId && name.trim() && description.trim()
+
+  const handlePublish = () => {
+    if (!canPublish) return
+    const listing = publishAgent({
+      name,
+      description,
+      tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+      category,
+      readme,
+      author,
+      config: {
+        baseAgentId: selected.id,
+        provider: selected.provider,
+        systemPrompt: selected.systemPrompt,
+        outputType: selected.outputType ?? 'text',
+      },
+    })
+    onPublished(listing)
+  }
+
+  const inputClass = `w-full px-3 py-2 rounded-lg border text-sm transition-all
+    dark:bg-surface-card dark:border-border dark:text-text-primary dark:placeholder-text-muted
+    bg-white border-gray-200 text-gray-900 placeholder-gray-400
+    focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50`
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Publish agent to marketplace"
+    >
+      <div
+        className="w-full max-w-lg max-h-[85vh] overflow-y-auto rounded-xl border p-5
+          dark:bg-surface dark:border-border bg-white border-gray-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-bold dark:text-text-primary text-gray-900">
+            Publish to Marketplace
+          </h2>
+          <button onClick={onClose} aria-label="Close" className="p-1 rounded-md dark:hover:bg-surface-hover hover:bg-gray-100">
+            <X size={15} className="dark:text-text-secondary text-gray-500" />
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+              Agent <span className="text-red-400">*</span>
+            </label>
+            <select value={agentId} onChange={(e) => setAgentId(e.target.value)} className={inputClass}>
+              <option value="">Select an agent to publish...</option>
+              {agents.map((a) => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+              Display Name <span className="text-red-400">*</span>
+            </label>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="My Agent Pack" className={inputClass} />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+              Description <span className="text-red-400">*</span>
+            </label>
+            <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={2} placeholder="What does this agent do?" className={inputClass} />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">Category</label>
+              <select value={category} onChange={(e) => setCategory(e.target.value)} className={inputClass}>
+                {MARKETPLACE_CATEGORIES.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">Author</label>
+              <input value={author} onChange={(e) => setAuthor(e.target.value)} placeholder="Your name" className={inputClass} />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+              Tags <span className="dark:text-text-muted text-gray-400 font-normal">(comma separated)</span>
+            </label>
+            <input value={tags} onChange={(e) => setTags(e.target.value)} placeholder="summarizer, research, markdown" className={inputClass} />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium dark:text-text-secondary text-gray-600 mb-1">
+              README <span className="dark:text-text-muted text-gray-400 font-normal">(optional)</span>
+            </label>
+            <textarea value={readme} onChange={(e) => setReadme(e.target.value)} rows={3} placeholder="Usage notes, examples, tips..." className={inputClass} />
+          </div>
+
+          <div className="flex items-start gap-2 p-2.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+            <ShieldCheck size={14} className="text-emerald-400 flex-shrink-0 mt-0.5" />
+            <p className="text-[11px] text-emerald-400/90">
+              Credential fields (API keys, tokens, secrets) are replaced with placeholders before publishing. Importers must supply their own values.
+            </p>
+          </div>
+
+          <button
+            onClick={handlePublish}
+            disabled={!canPublish}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold text-white
+              bg-accent hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+          >
+            <UploadCloud size={15} />
+            Publish
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ListingCard({ listing, onImport, onRate, imported }) {
+  return (
+    <div
+      className="rounded-lg border p-4 flex flex-col gap-2.5 transition-all
+        dark:bg-surface-card dark:border-border dark:hover:border-accent/40
+        bg-white border-gray-200 hover:border-accent/40 hover:shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 truncate">{listing.name}</h3>
+          <p className="text-[11px] dark:text-text-muted text-gray-400">by {listing.author}</p>
+        </div>
+        <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-medium bg-accent/10 text-accent">
+          {listing.category}
+        </span>
+      </div>
+
+      <p className="text-xs dark:text-text-secondary text-gray-600 line-clamp-2">{listing.description}</p>
+
+      {listing.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {listing.tags.map((tag) => (
+            <span
+              key={tag}
+              className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px]
+                dark:bg-surface-hover dark:text-text-secondary bg-gray-100 text-gray-600"
+            >
+              <Tag size={9} />
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between mt-auto pt-1">
+        <StarRating listing={listing} onRate={onRate} />
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] dark:text-text-muted text-gray-400">
+            {listing.importCount} import{listing.importCount === 1 ? '' : 's'}
+          </span>
+          <button
+            onClick={() => onImport(listing.id)}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors
+              bg-accent/10 text-accent hover:bg-accent hover:text-white"
+          >
+            {imported ? <Check size={11} /> : <Download size={11} />}
+            {imported ? 'Imported' : 'Import'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function MarketplacePage() {
+  useDocumentTitle('Agent Marketplace')
+
+  const [listings, setListings] = useState([])
+  const [agents, setAgents] = useState([])
+  const [search, setSearch] = useState('')
+  const [category, setCategory] = useState('')
+  const [showPublish, setShowPublish] = useState(false)
+  const [importedIds, setImportedIds] = useState(new Set())
+  const [notice, setNotice] = useState(null)
+
+  useEffect(() => {
+    setListings(loadListings())
+    loadAllAgents().then(setAgents)
+  }, [])
+
+  const visible = useMemo(
+    () => filterListings(listings, { search, category }),
+    [listings, search, category]
+  )
+
+  const flash = (message) => {
+    setNotice(message)
+    setTimeout(() => setNotice(null), 3500)
+  }
+
+  const handleImport = (listingId) => {
+    const draft = importAgent(listingId)
+    if (!draft) return
+    setListings(loadListings())
+    setImportedIds((prev) => new Set(prev).add(listingId))
+    flash(
+      draft.pendingCredentialFields.length > 0
+        ? `Imported "${draft.name}". Configure ${draft.pendingCredentialFields.length} credential field(s) before running it.`
+        : `Imported "${draft.name}" into your workspace.`
+    )
+  }
+
+  const handleRate = (listingId, stars) => {
+    rateAgent(listingId, stars)
+    setListings(loadListings())
+  }
+
+  const handlePublished = (listing) => {
+    setShowPublish(false)
+    setListings(loadListings())
+    flash(`Published "${listing.name}" to the marketplace.`)
+  }
+
+  const inputClass = `px-3 py-2 rounded-lg border text-sm transition-all
+    dark:bg-surface-card dark:border-border dark:text-text-primary dark:placeholder-text-muted
+    bg-white border-gray-200 text-gray-900 placeholder-gray-400
+    focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent/50`
+
+  return (
+    <div className="max-w-5xl mx-auto animate-fade-in">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 mb-5 flex-wrap">
+        <div className="flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center">
+            <Store size={16} className="text-accent" />
+          </div>
+          <div>
+            <h1 className="text-base font-bold dark:text-text-primary text-gray-900">Agent Marketplace</h1>
+            <p className="text-[11px] dark:text-text-muted text-gray-400">
+              Publish your agents and import ones built by the community
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setShowPublish(true)}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold text-white
+            bg-accent hover:bg-accent-hover transition-all active:scale-[0.98]"
+        >
+          <UploadCloud size={14} />
+          Publish to Marketplace
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-2 mb-5 flex-wrap">
+        <div className="relative flex-1 min-w-[220px]">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 dark:text-text-muted text-gray-400" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or tag..."
+            aria-label="Search marketplace"
+            className={`${inputClass} w-full pl-9`}
+          />
+        </div>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          aria-label="Filter by category"
+          className={inputClass}
+        >
+          <option value="">All categories</option>
+          {MARKETPLACE_CATEGORIES.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Notice */}
+      {notice && (
+        <div className="mb-4 p-3 rounded-lg border bg-emerald-500/10 border-emerald-500/20 animate-fade-in">
+          <p className="text-xs font-medium text-emerald-400">{notice}</p>
+        </div>
+      )}
+
+      {/* Grid */}
+      {visible.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {visible.map((listing) => (
+            <ListingCard
+              key={listing.id}
+              listing={listing}
+              onImport={handleImport}
+              onRate={handleRate}
+              imported={importedIds.has(listing.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-16">
+          <Store size={28} className="mx-auto mb-3 dark:text-text-muted text-gray-300" />
+          <p className="text-sm dark:text-text-secondary text-gray-500 mb-1">
+            {listings.length === 0 ? 'The marketplace is empty.' : 'No agents match your filters.'}
+          </p>
+          <p className="text-xs dark:text-text-muted text-gray-400">
+            {listings.length === 0
+              ? 'Be the first to publish an agent for the community.'
+              : 'Try a different search term or category.'}
+          </p>
+        </div>
+      )}
+
+      {showPublish && (
+        <PublishModal agents={agents} onClose={() => setShowPublish(false)} onPublished={handlePublished} />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Agents were private to each workspace. This PR adds a Marketplace page at `/marketplace` (linked from the sidebar) where users can publish agents and import ones shared by the community.

## Publishing

**Publish to Marketplace** opens a modal to select a registry agent and provide a display name, description, category, tags, author, and optional README. Before storing, the config passes through `sanitizeAgentConfig()`: any field whose key matches api key, token, secret, password, credential, or auth patterns is deep-replaced with a `YOUR_FIELD_HERE` placeholder, and the replaced paths are recorded.

## Browse and import

Cards show name, description, author, tag chips, category, import count, and average rating. Search matches name and tags; a category filter covers data processing, content generation, and research.

**Import** copies the sanitized config into the user's workspace as a draft flagged with `pendingCredentialFields`, so an imported agent cannot run until the user supplies real credential values. Each import increments the listing's import count.

## Rating

One-to-five star rating with one vote per user per agent: re-rating replaces the prior vote instead of double counting. Cards display the average and vote count.

## Acceptance criteria

- Publishing sanitizes all credential fields before storing the config.
- Imported agents require credential configuration before their first run (drafts carry `readyToRun: false` plus the pending field list).
- One vote per user per agent, with average rating and vote count displayed.

## Storage

Everything persists in localStorage behind `src/lib/marketplace.js`, consistent with how favorites and collections already persist in this app. Every helper degrades gracefully when storage is unavailable. The storage layer is isolated in one module, so swapping it for a Supabase table later only touches that file.

## Testing

- `npm run build` passes locally.
- Verified sanitization (nested credential fields replaced, paths recorded), search/category filtering, import count increments, and vote-replacement rating logic.

Closes #644