### PR TITLE
feat: create new agent terraform-config-generator.js

### DIFF
--- a/src/agents/definitions/terraform-config-generator.js
+++ b/src/agents/definitions/terraform-config-generator.js
@@ -1,0 +1,84 @@
+const terraformConfigGeneratorAgent = {
+    id: 'terraform-config-generator',
+    name: 'Terraform Config Generator Agent',
+    description: 'Turns a plain-English infrastructure description into ready-to-use Terraform configuration (main.tf, variables.tf, outputs.tf) for your chosen cloud provider.',
+    category: 'Engineering',
+    icon: 'Server',
+    provider: 'any',
+    defaultProvider: 'openai',
+    model: 'gpt-4o',
+    inputs: [
+        {
+            id: 'infra_description',
+            label: 'Infrastructure Description',
+            type: 'textarea',
+            placeholder: 'e.g. A VPC with 2 public subnets, an EC2 instance, and an RDS PostgreSQL database',
+            required: true,
+        },
+        {
+            id: 'cloud_provider',
+            label: 'Cloud Provider',
+            type: 'select',
+            options: ['AWS', 'GCP', 'Azure', 'DigitalOcean'],
+            defaultValue: 'AWS',
+            required: true,
+        },
+        {
+            id: 'environment',
+            label: 'Environment',
+            type: 'select',
+            options: ['dev', 'staging', 'production'],
+            defaultValue: 'dev',
+            required: true,
+        },
+        {
+            id: 'include_variables_file',
+            label: 'Include Variables File',
+            type: 'select',
+            options: ['yes', 'no'],
+            defaultValue: 'yes',
+            required: true,
+        },
+    ],
+    systemPrompt: `You are an expert Cloud Infrastructure Engineer specializing in writing clean, production-grade Terraform (HCL) configuration.
+
+Based on the user's inputs:
+- Infrastructure Description: a plain-English description of the desired infrastructure.
+- Cloud Provider: the target cloud provider (AWS, GCP, Azure, or DigitalOcean). Use the correct, current Terraform provider block and resource naming conventions for that provider.
+- Environment: the deployment environment (dev, staging, production). Reflect this in naming, tagging/labels, and sizing choices (e.g. smaller/cheaper defaults for dev, more resilient defaults for production).
+- Include Variables File: whether the user wants inputs extracted into a separate variables.tf with sensible defaults, or hardcoded inline in main.tf.
+
+Provide a highly professional, detailed, and tailored output using the following structure:
+
+# Terraform Configuration
+
+## 1. Executive Summary
+- **Cloud Provider**: the selected provider and Terraform provider version constraint used.
+- **Architecture Overview**: 1-2 sentence description of the resources being provisioned and how they relate.
+
+## 2. main.tf
+A complete, valid \`main.tf\` code block containing:
+- The \`terraform\` block with required_providers and version constraints.
+- The provider block.
+- All resource definitions needed to satisfy the infrastructure description, using variables (via \`var.*\`) if a variables file was requested, or sensible literal values if not.
+- Sensible tagging/labeling for the chosen environment.
+
+## 3. variables.tf
+If "Include Variables File" is "yes", provide a complete \`variables.tf\` code block declaring every variable referenced in main.tf, each with a type, description, and sensible default where appropriate. If "no" was selected, state "Not requested — all values are inlined in main.tf." instead of a code block.
+
+## 4. outputs.tf
+A complete \`outputs.tf\` code block exposing the useful identifiers a user would need after apply (e.g. VPC ID, instance public IP/DNS, database endpoint, connection strings without secrets).
+
+## 5. Resource-by-Resource Explanation
+A bulleted list explaining, for each resource block, what it does and why it's configured the way it is (briefly).
+
+## 6. Notes & Next Steps
+- Any assumptions made due to ambiguity in the description.
+- Security or cost considerations relevant to the chosen environment (e.g. state locking, secrets management, restricting security group ingress, enabling deletion protection for production databases).
+- Suggested \`terraform init\` / \`plan\` / \`apply\` next steps.
+
+Use idiomatic, current Terraform syntax (Terraform >= 1.x, HCL2). Format the response using clean, beautiful markdown with properly fenced \`\`\`hcl code blocks for each file.`,
+    outputType: 'markdown',
+};
+
+export default terraformConfigGeneratorAgent;


### PR DESCRIPTION
## What does this PR do?
Add Terraform Config Generator Agent
Summary
Adds a new Engineering-category agent that converts a plain-English infrastructure description into ready-to-use Terraform configuration (main.tf, variables.tf, outputs.tf) for AWS, GCP, Azure, or DigitalOcean.
Changes

Added src/agents/definitions/terraform-config-generator.js
New agent id: 'terraform-config-generator', category: 'Engineering', icon: 'Server'
Inputs: infrastructure description (textarea), cloud provider (select), environment (select), include variables file (select)
systemPrompt produces: executive summary, main.tf, variables.tf (conditional on user choice), outputs.tf, resource-by-resource explanation, and notes/next steps (assumptions, security/cost considerations, suggested terraform CLI steps)
outputType: 'markdown', with HCL fenced code blocks for each generated file

fixes #677 

## Type of change
- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [ ] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
<!-- Add screenshots here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform configuration generator option.
  * Supports entering infrastructure details, choosing a cloud provider and environment, and optionally creating a separate variables file.
  * Produces structured Terraform outputs with an accompanying explanation and next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

ad I am opening this pr as a GSSoC'26 contributor
