### PR TITLE
feat: add OpenAPI Spec Generator agent  #680

### DIFF
--- a/src/agents/definitions/openapi-spec-generator.js
+++ b/src/agents/definitions/openapi-spec-generator.js
@@ -1,0 +1,91 @@
+export default {
+  id: "openapi-spec-generator",
+  createdAt: "2025-07-02",
+  name: "OpenAPI Spec Generator",
+  description:
+    "Describe your API in plain English and get a complete, valid OpenAPI 3.0 YAML specification with paths, parameters, request bodies, and response schemas.",
+  category: "Engineering",
+  icon: "FileCode",
+  provider: "any",
+  defaultProvider: "openai",
+  model: "gpt-4o",
+  exampleInputs: {
+    apiName: "User Management API",
+    apiDescription: "A simple REST API for managing users in a SaaS application.",
+    endpoints: "GET /users — list all users\nPOST /users — create a new user\nGET /users/{id} — get a single user\nPUT /users/{id} — update a user\nDELETE /users/{id} — delete a user",
+    authType: "Bearer JWT",
+    includeExamples: "yes",
+  },
+  inputs: [
+    {
+      id: "apiName",
+      label: "API name",
+      type: "text",
+      placeholder: "e.g. User Management API",
+      required: true,
+    },
+    {
+      id: "apiDescription",
+      label: "API description",
+      type: "textarea",
+      placeholder: "Explain what your API does, who it is for, and any relevant context...",
+      required: true,
+    },
+    {
+      id: "endpoints",
+      label: "Endpoints to include",
+      type: "textarea",
+      placeholder: "GET /users — list all users\nPOST /users — create a new user\nGET /users/{id} — get a single user\nPUT /users/{id} — update a user\nDELETE /users/{id} — delete a user",
+      required: true,
+    },
+    {
+      id: "authType",
+      label: "Auth type",
+      type: "select",
+      options: ["None", "API Key", "Bearer JWT", "OAuth2"],
+      defaultValue: "Bearer JWT",
+      required: true,
+    },
+    {
+      id: "includeExamples",
+      label: "Include example request/response",
+      type: "select",
+      options: ["yes", "no"],
+      defaultValue: "yes",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are an API documentation expert. Given an API name, description, endpoints, auth type, and whether to include examples, generate a complete, valid OpenAPI 3.0 YAML specification.
+
+Return ONLY the YAML code block, nothing else. The output must start with \`\`\`yaml and end with \`\`\`.
+
+The spec must include:
+
+1. **Info section** — title, description, version ("1.0.0")
+2. **Servers section** — a generic localhost server URL (http://localhost:3000)
+3. **Paths** — every endpoint the user listed
+4. **Parameters** — path parameters, query parameters (e.g. pagination, filtering), and header parameters inferred from the context
+5. **Request bodies** — for POST, PUT, and PATCH endpoints, define JSON request body schemas with proper types
+6. **Response schemas** — for every operation, define success (200/201) and error (400/404/500) response schemas
+7. **Components** — reusable schemas in the components/schemas section
+
+If the user selected an auth type:
+- **API Key** → add a header parameter "X-API-Key" globally or via security scheme
+- **Bearer JWT** → add BearerAuth security scheme with type: http, scheme: bearer, bearerFormat: JWT
+- **OAuth2** → add OAuth2 security scheme with implicit flow and a placeholder authorizationUrl
+
+If examples are enabled (includeExamples === "yes"), include example values for:
+- Request body properties (use realistic but fake data)
+- Response body properties
+
+Rules:
+- Output valid YAML that passes OpenAPI 3.0 validation
+- Infer property types (string, integer, boolean, array, object) from endpoint names and descriptions
+- Use proper HTTP methods and status codes
+- Include proper schema types and formats (e.g. "date-time" for dates, "email" for emails, "int64" for IDs)
+- Add a tags section grouping endpoints by resource
+- Never include comments in the YAML — the spec itself must be clean
+- Use snake_case for property names`,
+  outputType: "markdown",
+  suggestedChainFrom: ["api-doc-generator", "code-migration-guide"],
+};

--- a/src/agents/definitions/openapi-spec-generator.js
+++ b/src/agents/definitions/openapi-spec-generator.js
@@ -61,18 +61,19 @@ Return ONLY the YAML code block, nothing else. The output must start with \`\`\`
 
 The spec must include:
 
-1. **Info section** — title, description, version ("1.0.0")
-2. **Servers section** — a generic localhost server URL (http://localhost:3000)
-3. **Paths** — every endpoint the user listed
-4. **Parameters** — path parameters, query parameters (e.g. pagination, filtering), and header parameters inferred from the context
-5. **Request bodies** — for POST, PUT, and PATCH endpoints, define JSON request body schemas with proper types
-6. **Response schemas** — for every operation, define success (200/201) and error (400/404/500) response schemas
-7. **Components** — reusable schemas in the components/schemas section
+1. **OpenAPI version field** — \`openapi: 3.0.3\` as the very first top-level field
+2. **Info section** — title, description, version ("1.0.0")
+3. **Servers section** — a generic localhost server URL (http://localhost:3000)
+4. **Paths** — every endpoint the user listed
+5. **Parameters** — path parameters, query parameters (e.g. pagination, filtering), and header parameters inferred from the context
+6. **Request bodies** — for POST, PUT, and PATCH endpoints, define JSON request body schemas with proper types
+7. **Response schemas** — for every operation, define success (200/201) and error (400/404/500) response schemas
+8. **Components** — reusable schemas in the components/schemas section
 
 If the user selected an auth type:
 - **API Key** → add a header parameter "X-API-Key" globally or via security scheme
 - **Bearer JWT** → add BearerAuth security scheme with type: http, scheme: bearer, bearerFormat: JWT
-- **OAuth2** → add OAuth2 security scheme with implicit flow and a placeholder authorizationUrl
+- **OAuth2** → add OAuth2 security scheme with type: oauth2, the appropriate flow (implicit, authorizationCode, clientCredentials, or password), placeholder authorization/token URLs where applicable, and a non-empty scopes object (use placeholder scopes such as \`read\` and \`write\` if the user doesn't specify any)
 
 If examples are enabled (includeExamples === "yes"), include example values for:
 - Request body properties (use realistic but fake data)


### PR DESCRIPTION
## What does this PR do?

Adds the **OpenAPI Spec Generator** agent that converts a plain English API description into a complete, valid **OpenAPI 3.0** YAML specification.

### Features
- Generates OpenAPI 3.0 compliant YAML
- Creates paths, operations, and parameters
- Supports request bodies and response schemas
- Configures authentication (API Key, Bearer JWT, OAuth2)
- Optionally includes example request and response values
- Produces a ready-to-use API specification for documentation and development

## Type of change

- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

closes #680 

## Checklist

- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new generator that creates complete OpenAPI 3.0 specifications in YAML.
  * You can provide API details (endpoints, authentication type, request/response structure) and optionally include example values.
  * Output is formatted for easy use as a valid OpenAPI 3.0 document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->