### PR TITLE
fix: avoid fallback Supabase requests

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,9 +1,40 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'http://localhost:54321'
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'dummy'
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-export const supabase = supabaseUrl && supabaseAnonKey && supabaseUrl !== 'undefined' 
+export const isSupabaseConfigured =
+  Boolean(supabaseUrl && supabaseAnonKey) &&
+  supabaseUrl !== 'undefined' &&
+  supabaseAnonKey !== 'undefined'
+
+function createNoopQuery(result = { data: [], error: null }) {
+  const query = {
+    select: () => query,
+    insert: () => query,
+    update: () => query,
+    eq: () => query,
+    order: () => query,
+    single: () => createNoopQuery({ data: null, error: null }),
+    then: (resolve) => Promise.resolve(result).then(resolve),
+  }
+
+  return query
+}
+
+const noopChannel = {
+  on: () => noopChannel,
+  subscribe: () => noopChannel,
+}
+
+const noopSupabase = {
+  from: () => createNoopQuery(),
+  rpc: () => Promise.resolve({ data: null, error: null }),
+  channel: () => noopChannel,
+  removeChannel: () => Promise.resolve(),
+}
+
+export const supabase = isSupabaseConfigured
   ? createClient(supabaseUrl, supabaseAnonKey)
-  : { from: () => ({ select: () => ({ order: () => Promise.resolve({ data: [] }) }), insert: () => Promise.resolve({ data: null }), rpc: () => Promise.resolve({}) }) }
+  : noopSupabase
 


### PR DESCRIPTION
## Summary

- removes the localhost Supabase fallback when env vars are missing
- adds a no-op client for workflow query and realtime calls without configuration

## Validation

- npm run build

Closes #694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app behavior when Supabase settings are missing or invalid by using a safe fallback client instead of failing unexpectedly.
  * Added more reliable connection checks so the app can better detect whether Supabase is ready to use.

* **New Features**
  * Added a configuration status flag that helps the app determine if Supabase is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->