### PR TITLE
feat: expose OpenRouter provider

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -26,6 +26,11 @@ const providerColors = {
     text: "text-blue-400",
     border: "border-blue-500/20",
   },
+  openrouter: {
+    bg: "bg-sky-500/10",
+    text: "text-sky-400",
+    border: "border-sky-500/20",
+  },
   any: {
     bg: "bg-purple-500/10",
     text: "text-purple-400",
@@ -37,6 +42,7 @@ const providerLabels = {
   openai: "OpenAI",
   anthropic: "Anthropic",
   gemini: "Gemini",
+  openrouter: "OpenRouter",
   any: "Any Provider",
 };
 

--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -43,6 +43,7 @@ const providerLabels = {
   openai: "OpenAI",
   anthropic: "Anthropic",
   gemini: "Gemini",
+  openrouter: "OpenRouter",
   any: "Any",
 };
 
@@ -939,6 +940,7 @@ const getTokenCount = (text) => {
         { value: "openai", label: "OpenAI" },
         { value: "anthropic", label: "Anthropic" },
         { value: "gemini", label: "Gemini" },
+        { value: "openrouter", label: "OpenRouter" },
       ]}
     />
 

--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -13,6 +13,7 @@ const PROVIDERS = [
   { value: 'openai', label: 'OpenAI' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'gemini', label: 'Gemini' },
+  { value: 'openrouter', label: 'OpenRouter' },
 ]
 
 const providerLogos = {
@@ -25,6 +26,27 @@ const providerUrls = {
   openai: 'https://platform.openai.com/account/api-keys',
   anthropic: 'https://console.anthropic.com/keys',
   gemini: 'https://console.cloud.google.com/apis/credentials',
+  openrouter: 'https://openrouter.ai/keys',
+}
+
+function ProviderIcon({ provider, label }) {
+  const logo = providerLogos[provider]
+
+  if (logo) {
+    return (
+      <img
+        src={logo}
+        alt={`${label} logo`}
+        className="w-4 h-4 flex-shrink-0"
+      />
+    )
+  }
+
+  return (
+    <span className="w-4 h-4 rounded bg-accent/10 text-[8px] font-bold text-accent flex items-center justify-center flex-shrink-0">
+      OR
+    </span>
+  )
 }
 
 
@@ -75,13 +97,7 @@ export default function ApiKeyBar({
       : PROVIDERS.filter((p) => p.value === agentProvider)
   ).map((p) => ({
     ...p,
-    icon: (
-      <img
-        src={providerLogos[p.value]}
-        alt={`${p.label} logo`}
-        className="w-4 h-4 flex-shrink-0"
-      />
-    ),
+    icon: <ProviderIcon provider={p.value} label={p.label} />,
   }))
 
   const availableModels =
@@ -99,6 +115,10 @@ export default function ApiKeyBar({
     'Alt+3': () => {
       const p = availableProviders.find(p => p.value === 'gemini');
       if (p) setProvider('gemini');
+    },
+    'Alt+4': () => {
+      const p = availableProviders.find(p => p.value === 'openrouter');
+      if (p) setProvider('openrouter');
     },
   });
 

--- a/src/components/recommendation/RecommendationResultCard.jsx
+++ b/src/components/recommendation/RecommendationResultCard.jsx
@@ -2,11 +2,12 @@ import { Link } from 'react-router-dom'
 import * as Icons from 'lucide-react'
 import { ArrowRight } from 'lucide-react'
 
-const providerLabels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', any: 'Any Provider' }
+const providerLabels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', openrouter: 'OpenRouter', any: 'Any Provider' }
 const providerClasses = {
   openai: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/20',
   anthropic: 'bg-orange-500/10 text-orange-500 border-orange-500/20',
   gemini: 'bg-blue-500/10 text-blue-500 border-blue-500/20',
+  openrouter: 'bg-sky-500/10 text-sky-500 border-sky-500/20',
   any: 'bg-purple-500/10 text-purple-500 border-purple-500/20',
 }
 

--- a/src/lib/modelPricing.js
+++ b/src/lib/modelPricing.js
@@ -65,6 +65,24 @@ export const MODEL_PRICING = {
     outputCostPer1M: 0.60,
     contextWindow: 1000000,
   },
+  'openai/gpt-4o-mini': {
+    provider: 'openrouter',
+    inputCostPer1M: 0.15,
+    outputCostPer1M: 0.60,
+    contextWindow: 128000,
+  },
+  'anthropic/claude-3.5-sonnet': {
+    provider: 'openrouter',
+    inputCostPer1M: 3.00,
+    outputCostPer1M: 15.00,
+    contextWindow: 200000,
+  },
+  'google/gemini-2.5-flash': {
+    provider: 'openrouter',
+    inputCostPer1M: 0.15,
+    outputCostPer1M: 0.60,
+    contextWindow: 1000000,
+  },
 }
 
 export function getPricing(modelId) {

--- a/src/lib/resolveAgentModel.js
+++ b/src/lib/resolveAgentModel.js
@@ -17,12 +17,18 @@ export const MODELS = {
     { value: 'gemini-2.0-flash-exp', label: 'Gemini 2.0 Flash (Exp)' },
     { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
   ],
+  openrouter: [
+    { value: 'openai/gpt-4o-mini', label: 'GPT-4o Mini' },
+    { value: 'anthropic/claude-3.5-sonnet', label: 'Claude 3.5 Sonnet' },
+    { value: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  ],
 }
 
 export const MODEL_MAP = {
   openai: MODELS.openai[0].value,
   anthropic: MODELS.anthropic[0].value,
   gemini: MODELS.gemini[0].value,
+  openrouter: MODELS.openrouter[0].value,
 }
 
 export function resolveAgentModel(agent, actualProvider, selectedModel) {


### PR DESCRIPTION
## Summary

- adds OpenRouter to provider selection and provider labels
- adds OpenRouter model defaults and pricing entries
- keeps cards and recommendation results styled for the provider

## Validation

- npm run build

Closes #698
