### PR TITLE
docs: remove stale agent count

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ src/
 │   ├── definitions/          # Each agent in its own file (auto-collected)
 │   │   ├── pdf-summarizer.js
 │   │   ├── code-reviewer.js
-│   │   └── ... (33 files)
+│   │   └── ... more agent definitions
 │   ├── categories.js         # CATEGORIES constant
 │   └── registry.js           # Auto-collects all definitions via import.meta.glob
 ├── components/


### PR DESCRIPTION
## Summary

- removes the hardcoded agent definition count from the README project tree
- keeps the structure accurate as more definitions are added

## Validation

- documentation-only change

Closes #700
