### PR TITLE
fix: keep retry provider fixed

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -932,20 +932,22 @@ const getTokenCount = (text) => {
 </div>
 {showModelSwitcher && (
   <div className="mt-3 p-4 border rounded-lg flex flex-wrap gap-3 items-center">
-<CustomSelect
-      value={provider}
-      onChange={setProvider}
-      options={[
-        { value: "openai", label: "OpenAI" },
-        { value: "anthropic", label: "Anthropic" },
-        { value: "gemini", label: "Gemini" },
-      ]}
-    />
+    {agent.provider === "any" && (
+      <CustomSelect
+        value={provider}
+        onChange={setProvider}
+        options={[
+          { value: "openai", label: "OpenAI" },
+          { value: "anthropic", label: "Anthropic" },
+          { value: "gemini", label: "Gemini" },
+        ]}
+      />
+    )}
 
     <CustomSelect
       value={selectedModel}
       onChange={setSelectedModel}
-      options={MODELS[provider] || []}
+      options={MODELS[agent.provider === "any" ? provider : agent.provider] || []}
     />
 
     <button


### PR DESCRIPTION
## Summary

- hides provider switching for agents with a fixed provider
- keeps retry model options scoped to the provider that will actually run

## Validation

- npm run build

Closes #702
