### PR TITLE
fix: use common layout for Battle Mode pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,11 +60,6 @@ export default function App() {
       <ErrorBoundary>
         <Suspense fallback={<PageLoader />}>
           <Routes>
-            <Route path="/battle" element={<BattleModeLanding />} />
-            <Route path="/battle/setup" element={<BattleModeSetup />} />
-            <Route path="/battle/arena" element={<BattleModeArena />} />
-            <Route path="/battle/winner" element={<BattleModeWinner />} />
-
             <Route element={<MainLayout sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />}>
               <Route path="/" element={<HomePage />} />
               <Route path="/privacy" element={<Privacy />} />
@@ -72,19 +67,16 @@ export default function App() {
               <Route path="/suites" element={<SuitesPage />} />
               <Route path="/collections" element={<CollectionsPage />} />
               <Route path="/collections/:id" element={<CollectionDetailPage />} />
-
               <Route path="/scheduler" element={<SchedulerPage />} />
-
-
-            <Route path="/marketplace" element={<MarketplacePage />} />
-            <Route path="/workflows" element={<WorkflowLibrary />} />
-            <Route path="/workflows/build" element={<WorkflowBuilder />} />
-            <Route path="/workflows/:id" element={<WorkflowDetail />} />
-            <Route path="/workflows/:id/run" element={<WorkflowRunner />} />
-            <Route path="/battle" element={<BattleModeLanding />} />
-            <Route path="/battle/setup" element={<BattleModeSetup />} />
-            <Route path="/battle/arena" element={<BattleModeArena />} />
-            <Route path="/battle/winner" element={<BattleModeWinner />} />
+              <Route path="/marketplace" element={<MarketplacePage />} />
+              <Route path="/workflows" element={<WorkflowLibrary />} />
+              <Route path="/workflows/build" element={<WorkflowBuilder />} />
+              <Route path="/workflows/:id" element={<WorkflowDetail />} />
+              <Route path="/workflows/:id/run" element={<WorkflowRunner />} />
+              <Route path="/battle" element={<BattleModeLanding />} />
+              <Route path="/battle/setup" element={<BattleModeSetup />} />
+              <Route path="/battle/arena" element={<BattleModeArena />} />
+              <Route path="/battle/winner" element={<BattleModeWinner />} />
               <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>


### PR DESCRIPTION
## Summary

This PR fixes the missing navigation bar on the Battle Mode pages by making them use the common application layout.

## Related Issue

Closes #666

## Changes

* Moved Battle Mode routes into the common `MainLayout`.
* Removed the standalone `BattleNavbar` from Battle Mode pages.
* Updated page spacing to align correctly with the shared layout.
* Ensured Battle Mode pages display the same global Navbar and Sidebar as the rest of the application.

## Screenshot 
<img width="1917" height="902" alt="image" src="https://github.com/user-attachments/assets/33834c74-5b22-4ecf-af8c-c8d19a4c0937" />

## Testing

* [ ] Added/updated tests
* [x] Tested locally

## Testing Steps

1. Start the development server.
2. Navigate to `/battle`.
3. Verify that the global navigation bar is visible.
4. Navigate through Battle Setup, Arena, and Winner pages.
5. Confirm there are no duplicate navbars and navigation works correctly.

## Contributor Details

* **Name:** Sargam Ghagre
* **GitHub Username:** Sargam-Ghagre
* **Program:** GSSoC 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app routing so marketplace, workflows, battle, and related sub-pages now load within the main layout consistently.
  * Improved route handling by keeping the page structure in one unified routing section, reducing navigation issues on nested pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->