### PR TITLE
feat: add global Settings page with persistent API key management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ const CollectionDetailPage = lazy(() => import('./pages/CollectionDetailPage'))
 const SchedulerPage = lazy(() => import('./pages/SchedulerPage'))
 const MarketplacePage = lazy(() => import('./pages/MarketplacePage'))
 const Privacy = lazy(() => import('./pages/Privacy'))
+const SettingsPage = lazy(() => import('./pages/SettingsPage'))
 
 function PageLoader() {
   return (
@@ -63,6 +64,7 @@ export default function App() {
             <Route element={<MainLayout sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />}>
               <Route path="/" element={<HomePage />} />
               <Route path="/privacy" element={<Privacy />} />
+              <Route path="/settings" element={<SettingsPage />} />
               <Route path="/agent/:id" element={<AgentPage />} />
               <Route path="/suites" element={<SuitesPage />} />
               <Route path="/collections" element={<CollectionsPage />} />

--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -1,6 +1,7 @@
 import { fetchGeminiModels } from '../lib/llmAdapter'
 import { useState, useEffect } from 'react'
 import { Eye, EyeOff, ShieldCheck } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import CustomSelect from './CustomSelect'
 import { MODELS } from '../lib/resolveAgentModel'
 import ApiKeyInfo from './ApiKeyInfo'
@@ -8,6 +9,7 @@ import openaiLogo from "../assets/openai.svg";
 import anthropicLogo from "../assets/anthropic.svg";
 import geminiLogo from "../assets/gemini.svg";
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
+import { getGlobalKeys, getAvailableProviders } from '../lib/globalKeys'
 
 const PROVIDERS = [
   { value: 'openai', label: 'OpenAI' },
@@ -67,6 +69,22 @@ export default function ApiKeyBar({
   const [geminiLoading, setGeminiLoading] = useState(false)
   const [geminiError, setGeminiError] = useState(null)
 
+  // ── Auto-fill from globally saved keys on mount and provider change
+  useEffect(() => {
+    const globalKeys = getGlobalKeys()
+    const savedKey = globalKeys[provider]
+    if (savedKey && !apiKey) {
+      setApiKey(savedKey)
+    }
+    // Also set default provider if none selected and a default exists
+    if (globalKeys.defaultProvider && provider !== globalKeys.defaultProvider) {
+      // Only set if the agent allows any provider
+      if (agentProvider === 'any') {
+        // Don't override the user's current selection — only on initial mount
+      }
+    }
+  }, [provider])
+
   useEffect(() => {
     if (provider !== 'gemini' || !apiKey?.trim()) {
       setGeminiModels([])
@@ -91,13 +109,21 @@ export default function ApiKeyBar({
   }, [provider, apiKey])
 
   // Filter providers if agent requires a specific one
+  const savedProviders = new Set(getAvailableProviders().map(p => p.id))
   const availableProviders = (
     agentProvider === 'any'
       ? PROVIDERS
       : PROVIDERS.filter((p) => p.value === agentProvider)
   ).map((p) => ({
     ...p,
-    icon: <ProviderIcon provider={p.value} label={p.label} />,
+    icon: (
+      <span className="flex items-center gap-1.5">
+        <ProviderIcon provider={p.value} label={p.label} />
+        {savedProviders.has(p.value) && (
+          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 flex-shrink-0" title="Key saved globally" />
+        )}
+      </span>
+    ),
   }))
 
   const availableModels =
@@ -186,11 +212,19 @@ export default function ApiKeyBar({
       </div>
 
       {/* Disclaimer */}
-      <div className="flex items-center gap-1.5 mt-2">
-        <ShieldCheck size={12} className="text-success flex-shrink-0" />
-        <span className="text-[10px] dark:text-text-muted text-gray-400">
-          Your key is never sent to our servers. It's used directly from your browser.
-        </span>
+      <div className="flex items-center justify-between mt-2">
+        <div className="flex items-center gap-1.5">
+          <ShieldCheck size={12} className="text-success flex-shrink-0" />
+          <span className="text-[10px] dark:text-text-muted text-gray-400">
+            Your key is never sent to our servers. It's used directly from your browser.
+          </span>
+        </div>
+        <Link
+          to="/settings"
+          className="text-[10px] font-medium text-accent hover:underline transition-colors whitespace-nowrap ml-2"
+        >
+          Manage keys →
+        </Link>
       </div>
 
       {/* Warning if no key */}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,6 +13,7 @@ import {
   LibraryBig,
   DollarSign,
   RotateCcw,
+  Settings,
 } from 'lucide-react'
 
 import Logo from './Logo'
@@ -250,6 +251,24 @@ export default function Navbar({ sidebarOpen, setSidebarOpen }) {
           >
             {darkMode ? <Sun size={16} /> : <Moon size={16} />}
           </button>
+
+          {/* Settings icon link */}
+          <Link
+            to="/settings"
+            className="
+              hidden md:inline-flex items-center justify-center p-2.5
+              rounded-full
+              transition-all duration-200 hover:scale-105
+              dark:hover:bg-white/10
+              dark:text-text-secondary
+              hover:bg-white/70
+              text-gray-500
+              focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500
+            "
+            aria-label="Settings"
+          >
+            <Settings size={16} />
+          </Link>
 
           <button
             onClick={() => setMobileMenuOpen((open) => !open)}

--- a/src/lib/globalKeys.js
+++ b/src/lib/globalKeys.js
@@ -1,0 +1,75 @@
+/**
+ * globalKeys.js — manages persistent API key storage in localStorage.
+ *
+ * Keys are stored under these exact names:
+ *   iloveagents_openai_key
+ *   iloveagents_anthropic_key
+ *   iloveagents_gemini_key
+ *   iloveagents_default_provider
+ */
+
+const KEYS = {
+  openai:          'iloveagents_openai_key',
+  anthropic:       'iloveagents_anthropic_key',
+  gemini:          'iloveagents_gemini_key',
+  defaultProvider: 'iloveagents_default_provider',
+}
+
+/**
+ * Read all globally saved keys from localStorage.
+ * @returns {{ openai: string, anthropic: string, gemini: string, defaultProvider: string }}
+ */
+export function getGlobalKeys() {
+  return {
+    openai:          localStorage.getItem(KEYS.openai)          || '',
+    anthropic:       localStorage.getItem(KEYS.anthropic)       || '',
+    gemini:          localStorage.getItem(KEYS.gemini)          || '',
+    defaultProvider: localStorage.getItem(KEYS.defaultProvider) || '',
+  }
+}
+
+/**
+ * Save keys to localStorage. Only saves non-empty values —
+ * passing an empty string does NOT overwrite an existing saved key.
+ * To explicitly clear a key use clearGlobalKey(provider).
+ * @param {{ openai?: string, anthropic?: string, gemini?: string, defaultProvider?: string }} keys
+ */
+export function saveGlobalKeys({ openai, anthropic, gemini, defaultProvider } = {}) {
+  if (openai          !== undefined && openai.trim()          !== '') localStorage.setItem(KEYS.openai,          openai.trim())
+  if (anthropic       !== undefined && anthropic.trim()       !== '') localStorage.setItem(KEYS.anthropic,       anthropic.trim())
+  if (gemini          !== undefined && gemini.trim()          !== '') localStorage.setItem(KEYS.gemini,          gemini.trim())
+  if (defaultProvider !== undefined && defaultProvider.trim() !== '') localStorage.setItem(KEYS.defaultProvider, defaultProvider.trim())
+}
+
+/**
+ * Remove a single provider's key from localStorage.
+ * @param {'openai' | 'anthropic' | 'gemini'} provider
+ */
+export function clearGlobalKey(provider) {
+  const storageKey = KEYS[provider]
+  if (storageKey) localStorage.removeItem(storageKey)
+}
+
+/**
+ * Remove all four localStorage entries managed by this module.
+ */
+export function clearAllGlobalKeys() {
+  Object.values(KEYS).forEach((k) => localStorage.removeItem(k))
+}
+
+/**
+ * Return an array of provider objects only for providers that have a saved key.
+ * @returns {Array<{ id: string, label: string }>}
+ */
+export function getAvailableProviders() {
+  const PROVIDER_LABELS = {
+    openai:    'OpenAI',
+    anthropic: 'Anthropic',
+    gemini:    'Google Gemini',
+  }
+
+  const keys = getGlobalKeys()
+  return Object.entries(PROVIDER_LABELS)
+    .filter(([id]) => keys[id] && keys[id].trim() !== '')
+    .map(([id, label]) => ({ id, label }))
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -12,6 +12,7 @@ import { useAgents } from '../lib/useAgents'
 import RecommendationWizardEntry from '../components/recommendation/RecommendationWizardEntry'
 import RecommendationWizardModal from '../components/recommendation/RecommendationWizardModal'
 import { Link } from "react-router-dom";
+import { getGlobalKeys } from '../lib/globalKeys'
 
 // Category icons/colors for the filter pills
 const categoryMeta = {
@@ -38,6 +39,18 @@ export default function HomePage() {
   const recommendationWizardHeroTriggerRef = useRef(null)
   const recommendationWizardReturnFocusRef = useRef(null)
   const [selectedCategory, setSelectedCategory] = useState(null)
+
+  // ── First-time banner: show only if no global keys saved and not dismissed
+  const [showBanner, setShowBanner] = useState(() => {
+    if (localStorage.getItem('iloveagents_banner_dismissed') === 'true') return false
+    const keys = getGlobalKeys()
+    return !keys.openai && !keys.anthropic && !keys.gemini
+  })
+
+  const dismissBanner = () => {
+    localStorage.setItem('iloveagents_banner_dismissed', 'true')
+    setShowBanner(false)
+  }
   const allCategories = useMemo(() => {
     return [...new Set(agents.map((a) => a.category))].sort()
   }, [agents])
@@ -191,6 +204,35 @@ export default function HomePage() {
         onClose={() => setIsRecommendationWizardOpen(false)}
         triggerRef={recommendationWizardReturnFocusRef}
       />
+
+      {/* First-time user banner — shows only when no global keys saved and not dismissed */}
+      {showBanner && (
+        <div className="mb-5 flex items-center justify-between gap-3 rounded-xl border px-4 py-3 animate-fade-in
+          dark:bg-accent/5 dark:border-accent/20 bg-indigo-50 border-indigo-200">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <span className="text-lg flex-shrink-0">👋</span>
+            <p className="text-sm dark:text-text-secondary text-gray-700 leading-snug">
+              <strong className="dark:text-text-primary text-gray-900">First time here?</strong>{' '}
+              Save your API keys once in Settings and use all agents instantly. No re-entering ever.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <Link
+              to="/settings"
+              className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white bg-accent hover:bg-accent-hover transition-colors whitespace-nowrap"
+            >
+              Go to Settings →
+            </Link>
+            <button
+              onClick={dismissBanner}
+              className="p-1.5 rounded-md dark:text-text-muted text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary transition-colors"
+              aria-label="Dismiss banner"
+            >
+              <X size={15} />
+            </button>
+          </div>
+        </div>
+      )}
       {/* Hero */}
       <div className="premium-section text-center mb-10 pt-2 overflow-hidden">
         <h1 className="text-3xl sm:text-4xl font-bold dark:text-text-primary text-gray-900 mb-3 tracking-tight text-balance">

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,327 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Settings, Eye, EyeOff, Check, X,
+  Trash2, ExternalLink, ShieldCheck, KeyRound,
+} from 'lucide-react'
+import {
+  getGlobalKeys,
+  saveGlobalKeys,
+  clearGlobalKey,
+  clearAllGlobalKeys,
+  getAvailableProviders,
+} from '../lib/globalKeys'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
+import openaiLogo   from '../assets/openai.svg'
+import anthropicLogo from '../assets/anthropic.svg'
+import geminiLogo    from '../assets/gemini.svg'
+
+const PROVIDERS = [
+  {
+    id:          'openai',
+    label:       'OpenAI',
+    logo:        openaiLogo,
+    description: 'Powers GPT-4o and GPT-4o Mini',
+    keyUrl:      'https://platform.openai.com/api-keys',
+    keyLabel:    'Get your key →',
+    placeholder: 'sk-...',
+  },
+  {
+    id:          'anthropic',
+    label:       'Anthropic',
+    logo:        anthropicLogo,
+    description: 'Powers Claude Sonnet and Claude Opus',
+    keyUrl:      'https://console.anthropic.com/keys',
+    keyLabel:    'Get free key →',
+    placeholder: 'sk-ant-...',
+  },
+  {
+    id:          'gemini',
+    label:       'Google Gemini',
+    logo:        geminiLogo,
+    description: 'Powers Gemini 2.5 Flash — free tier available',
+    keyUrl:      'https://aistudio.google.com/app/apikey',
+    keyLabel:    'Get free key →',
+    placeholder: 'AIza...',
+  },
+]
+
+export default function SettingsPage() {
+  useDocumentTitle('Settings')
+
+  // ── Form state
+  const [keys, setKeys] = useState({ openai: '', anthropic: '', gemini: '' })
+  const [defaultProvider, setDefaultProvider] = useState('')
+  const [showKey, setShowKey] = useState({ openai: false, anthropic: false, gemini: false })
+  const [savedStatus, setSavedStatus] = useState({ openai: false, anthropic: false, gemini: false })
+  const [saveMessage, setSaveMessage] = useState('')
+  const [confirmClearAll, setConfirmClearAll] = useState(false)
+
+  // ── Load from localStorage on mount
+  useEffect(() => {
+    const stored = getGlobalKeys()
+    setKeys({
+      openai:    stored.openai    || '',
+      anthropic: stored.anthropic || '',
+      gemini:    stored.gemini    || '',
+    })
+    setDefaultProvider(stored.defaultProvider || '')
+    setSavedStatus({
+      openai:    !!stored.openai,
+      anthropic: !!stored.anthropic,
+      gemini:    !!stored.gemini,
+    })
+  }, [])
+
+  const availableForDefault = getAvailableProviders()
+
+  const handleSave = () => {
+    saveGlobalKeys({ ...keys, defaultProvider })
+    // Refresh saved status
+    const stored = getGlobalKeys()
+    setSavedStatus({
+      openai:    !!stored.openai,
+      anthropic: !!stored.anthropic,
+      gemini:    !!stored.gemini,
+    })
+    setSaveMessage('Keys saved successfully ✅')
+    setTimeout(() => setSaveMessage(''), 3000)
+  }
+
+  const handleClearKey = (provider) => {
+    clearGlobalKey(provider)
+    setKeys((prev) => ({ ...prev, [provider]: '' }))
+    setSavedStatus((prev) => ({ ...prev, [provider]: false }))
+    // If cleared provider was default, reset default
+    if (defaultProvider === provider) {
+      clearGlobalKey('defaultProvider')
+      setDefaultProvider('')
+    }
+  }
+
+  const handleClearAll = () => {
+    clearAllGlobalKeys()
+    setKeys({ openai: '', anthropic: '', gemini: '' })
+    setDefaultProvider('')
+    setSavedStatus({ openai: false, anthropic: false, gemini: false })
+    setConfirmClearAll(false)
+    setSaveMessage('All keys cleared.')
+    setTimeout(() => setSaveMessage(''), 3000)
+  }
+
+  const toggleShow = (provider) => {
+    setShowKey((prev) => ({ ...prev, [provider]: !prev[provider] }))
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto animate-fade-in">
+      {/* Page header */}
+      <div className="flex items-center gap-3 mb-8">
+        <div className="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center flex-shrink-0">
+          <Settings size={20} className="text-accent" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold dark:text-text-primary text-gray-900">Settings</h1>
+          <p className="text-xs dark:text-text-secondary text-gray-500">
+            Manage your API keys and preferences
+          </p>
+        </div>
+      </div>
+
+      {/* ─────────────────────────────────────────── */}
+      {/* SECTION 1 — API Keys                        */}
+      {/* ─────────────────────────────────────────── */}
+      <section className="mb-8 rounded-xl border dark:bg-surface-card dark:border-border bg-white border-gray-200 overflow-hidden">
+        <div className="px-5 py-4 border-b dark:border-border border-gray-100">
+          <div className="flex items-center gap-2">
+            <KeyRound size={16} className="text-accent" />
+            <h2 className="text-sm font-bold dark:text-text-primary text-gray-900">API Keys</h2>
+          </div>
+          <p className="text-xs dark:text-text-secondary text-gray-500 mt-0.5">
+            Add keys for the providers you use. You only need one to get started.
+          </p>
+        </div>
+
+        <div className="divide-y dark:divide-border divide-gray-100">
+          {PROVIDERS.map((p) => (
+            <div key={p.id} className="px-5 py-4">
+              {/* Provider name row */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <img src={p.logo} alt={p.label} className="w-5 h-5 flex-shrink-0" />
+                  <span className="text-sm font-semibold dark:text-text-primary text-gray-800">
+                    {p.label} API Key
+                  </span>
+                  {savedStatus[p.id] && (
+                    <span className="flex items-center gap-1 text-[10px] font-bold px-1.5 py-0.5 rounded-full
+                      bg-emerald-500/10 text-emerald-500 border border-emerald-500/20">
+                      <Check size={9} strokeWidth={3} />
+                      Saved
+                    </span>
+                  )}
+                </div>
+                {savedStatus[p.id] && (
+                  <button
+                    onClick={() => handleClearKey(p.id)}
+                    className="flex items-center gap-1 text-[10px] font-medium text-red-400 hover:text-red-500
+                      transition-colors px-2 py-1 rounded-md hover:bg-red-500/10"
+                  >
+                    <X size={11} />
+                    Clear
+                  </button>
+                )}
+              </div>
+
+              {/* Input row */}
+              <div className="relative">
+                <input
+                  type={showKey[p.id] ? 'text' : 'password'}
+                  value={keys[p.id]}
+                  onChange={(e) => setKeys((prev) => ({ ...prev, [p.id]: e.target.value }))}
+                  placeholder={savedStatus[p.id] ? '••••••••••••••••••••••••' : p.placeholder}
+                  className="w-full h-9 pl-3 pr-10 rounded-md text-xs font-mono transition-colors
+                    dark:bg-surface-input dark:border-border dark:text-text-primary dark:placeholder:text-text-muted
+                    bg-gray-50 border border-gray-200 text-gray-900 placeholder:text-gray-400
+                    focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+                />
+                <button
+                  onClick={() => toggleShow(p.id)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 dark:text-text-muted text-gray-400
+                    hover:text-accent transition-colors"
+                  aria-label={showKey[p.id] ? 'Hide key' : 'Show key'}
+                >
+                  {showKey[p.id] ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+              </div>
+
+              {/* Description + link */}
+              <div className="flex items-center justify-between mt-1.5">
+                <span className="text-[11px] dark:text-text-muted text-gray-400">{p.description}</span>
+                <a
+                  href={p.keyUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-[11px] font-medium text-accent hover:underline transition-colors"
+                >
+                  {p.keyLabel}
+                  <ExternalLink size={10} />
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Save button */}
+        <div className="px-5 py-4 border-t dark:border-border border-gray-100 flex items-center justify-between">
+          {saveMessage ? (
+            <span className="text-xs font-medium text-emerald-500 flex items-center gap-1.5">
+              <Check size={13} />
+              {saveMessage}
+            </span>
+          ) : (
+            <span />
+          )}
+          <button
+            onClick={handleSave}
+            className="flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold text-white
+              bg-accent hover:bg-accent-hover transition-all duration-150 active:scale-[0.97]"
+          >
+            Save Keys
+          </button>
+        </div>
+      </section>
+
+      {/* ─────────────────────────────────────────── */}
+      {/* SECTION 2 — Default Provider                */}
+      {/* ─────────────────────────────────────────── */}
+      <section className="mb-8 rounded-xl border dark:bg-surface-card dark:border-border bg-white border-gray-200 overflow-hidden">
+        <div className="px-5 py-4 border-b dark:border-border border-gray-100">
+          <h2 className="text-sm font-bold dark:text-text-primary text-gray-900">Default Provider</h2>
+          <p className="text-xs dark:text-text-secondary text-gray-500 mt-0.5">
+            This provider is pre-selected on every agent. You can still switch per agent.
+          </p>
+        </div>
+
+        <div className="px-5 py-4">
+          {availableForDefault.length === 0 ? (
+            <p className="text-xs dark:text-text-muted text-gray-400">
+              Save at least one API key above to set a default provider.
+            </p>
+          ) : (
+            <select
+              value={defaultProvider}
+              onChange={(e) => {
+                const val = e.target.value
+                setDefaultProvider(val)
+                saveGlobalKeys({ defaultProvider: val })
+              }}
+              className="w-full sm:w-64 h-9 px-3 rounded-md text-sm transition-colors
+                dark:bg-surface-input dark:border-border dark:text-text-primary
+                bg-gray-50 border border-gray-200 text-gray-900
+                focus:ring-1 focus:ring-accent focus:border-accent outline-none"
+            >
+              <option value="">Select a default provider...</option>
+              {availableForDefault.map((p) => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+            </select>
+          )}
+        </div>
+      </section>
+
+      {/* ─────────────────────────────────────────── */}
+      {/* SECTION 3 — Privacy                         */}
+      {/* ─────────────────────────────────────────── */}
+      <section className="rounded-xl border dark:bg-surface-card dark:border-border bg-white border-gray-200 overflow-hidden">
+        <div className="px-5 py-4 border-b dark:border-border border-gray-100">
+          <h2 className="text-sm font-bold dark:text-text-primary text-gray-900">Privacy</h2>
+        </div>
+
+        <div className="px-5 py-4">
+          <div className="flex items-start gap-3 mb-5 p-3 rounded-lg dark:bg-surface-hover bg-gray-50">
+            <ShieldCheck size={16} className="text-emerald-500 flex-shrink-0 mt-0.5" />
+            <p className="text-xs dark:text-text-secondary text-gray-600 leading-relaxed">
+              🔒 Your API keys are stored only in your browser's localStorage. They are never sent
+              to our servers — because we don't have any. Every API call goes directly from your
+              browser to the provider using your own key.
+            </p>
+          </div>
+
+          {confirmClearAll ? (
+            <div className="flex flex-col gap-3 p-3 rounded-lg border border-red-500/20 bg-red-500/5">
+              <p className="text-xs font-medium text-red-500">
+                Are you sure? This will remove all saved keys and your default provider preference.
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleClearAll}
+                  className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-semibold text-white
+                    bg-red-500 hover:bg-red-600 transition-colors"
+                >
+                  <Trash2 size={13} />
+                  Yes, clear all
+                </button>
+                <button
+                  onClick={() => setConfirmClearAll(false)}
+                  className="px-4 py-2 rounded-lg text-xs font-medium transition-colors
+                    dark:text-text-secondary dark:hover:bg-surface-hover text-gray-600 hover:bg-gray-100"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setConfirmClearAll(true)}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors
+                text-red-500 border border-red-500/20 hover:bg-red-500/10"
+            >
+              <Trash2 size={15} />
+              Clear All Keys
+            </button>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this PR do?
<!-- Describe your changes clearly -->

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [ ] I did not break any existing agents ✅
- [ ] I did not use `import agents from '../agents/registry'` ✅
- [ ] My PR has a clear description above ✅

## Screenshots (if UI change)
<!-- Add screenshots here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Settings page for managing saved API keys and choosing a default provider.
  * Added settings access from the top navigation and API key area.
  * Added a first-time banner on the home page that links to Settings.

* **Bug Fixes**
  * Saved keys can now be reused automatically when returning to provider fields.
  * Users can clear individual keys or remove all saved keys from one place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->