### PR TITLE
fix: pass workflow steps to conditional validator (#747)

### DIFF
--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -183,7 +183,7 @@ export default function WorkflowRunner() {
       const step = execSteps[i]
 
       if (step.kind === 'conditional') {
-        const problems = validateConditionalStep(step.stepDef)
+        const problems = validateConditionalStep(step.stepDef, workflow.agents)
         const { conditionValue, branchLabel, branchAgents } = evaluateConditionalStep(step.stepDef, context)
 
         if (!branchLabel) {


### PR DESCRIPTION
## What does this PR do?

### Related Issue

Closes #747

### Summary

This PR fixes a bug where circular workflow validation could be bypassed because `validateConditionalStep()` was called without the complete workflow steps collection.

Previously, the validator defaulted the `allSteps` parameter to an empty array, preventing the circular dependency detection logic from traversing conditional branches correctly. As a result, workflows containing circular conditional references could pass validation.

### Changes Made

* Pass the complete workflow steps collection to `validateConditionalStep()` in `WorkflowRunner`.
* Restore proper circular dependency detection during workflow execution.
* Keep the change minimal and limited to the validation call site.

### Testing

* Reproduced the issue with a circular conditional workflow.
* Verified that circular workflows are now detected and rejected.
* Verified that valid workflows continue to execute normally.
* Ran `npm run build` successfully with no build errors.

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)

N/A (No UI changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional workflow steps now use the workflow’s agent definitions during validation, which can improve accuracy when evaluating branches before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->