### PR TITLE
fix(security): add expiry timestamps to API keys

### DIFF
--- a/src/lib/useApiKey.js
+++ b/src/lib/useApiKey.js
@@ -1,6 +1,42 @@
 import { useState, useEffect, useCallback } from 'react'
 
 const STORAGE_PREFIX = 'ila_apikey_'
+const EXPIRY_MS = 8 * 60 * 60 * 1000 // 8 hours
+
+/**
+ * Safely retrieve an API key if it exists and hasn't expired.
+ * Keys are wrapped with expiry timestamps to prevent indefinite persistence
+ * even if storage backend is changed to localStorage.
+ */
+function getSafeApiKey(provider) {
+  const raw = sessionStorage.getItem(STORAGE_PREFIX + provider)
+  if (!raw) return null
+  try {
+    const { key, expiresAt } = JSON.parse(raw)
+    if (Date.now() > expiresAt) {
+      sessionStorage.removeItem(STORAGE_PREFIX + provider)
+      return null
+    }
+    return key
+  } catch {
+    // Migrate legacy plaintext keys (no expiry)
+    return raw
+  }
+}
+
+/**
+ * Store an API key with an expiry timestamp.
+ */
+function setSafeApiKey(provider, key) {
+  if (key) {
+    sessionStorage.setItem(STORAGE_PREFIX + provider, JSON.stringify({
+      key,
+      expiresAt: Date.now() + EXPIRY_MS,
+    }))
+  } else {
+    sessionStorage.removeItem(STORAGE_PREFIX + provider)
+  }
+}
 
 /**
  * Custom hook for managing API key state with optional sessionStorage persistence.
@@ -12,7 +48,7 @@ export function useApiKey() {
 
   // Load saved key on mount and provider change
   useEffect(() => {
-    const saved = sessionStorage.getItem(STORAGE_PREFIX + provider)
+    const saved = getSafeApiKey(provider)
     if (saved) {
       setApiKey(saved)
       setSaveForSession(true)
@@ -27,7 +63,7 @@ export function useApiKey() {
     (key) => {
       setApiKey(key)
       if (saveForSession && key) {
-        sessionStorage.setItem(STORAGE_PREFIX + provider, key)
+        setSafeApiKey(provider, key)
       }
     },
     [provider, saveForSession]
@@ -37,9 +73,9 @@ export function useApiKey() {
     (save) => {
       setSaveForSession(save)
       if (save && apiKey) {
-        sessionStorage.setItem(STORAGE_PREFIX + provider, apiKey)
+        setSafeApiKey(provider, apiKey)
       } else {
-        sessionStorage.removeItem(STORAGE_PREFIX + provider)
+        setSafeApiKey(provider, null)
       }
     },
     [provider, apiKey]


### PR DESCRIPTION
## Problem
API keys were stored in sessionStorage indefinitely with no expiry. While sessionStorage clears on browser close, the lack of explicit expiry made keys vulnerable if storage backend was changed to localStorage or accessed directly.

## Fix
- Added 8-hour expiry timestamps to all stored API keys
- Created getSafeApiKey() that validates expiry before returning
- Expired keys purged automatically on retrieval
- Maintains backward compatibility with legacy keys

Fixes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys saved for the current session now expire automatically after 8 hours.
  * Existing saved keys are still recognized and migrated seamlessly.

* **Bug Fixes**
  * Improved handling of saved API keys to avoid issues with invalid or expired stored values.
  * Clearing session-based key saving now removes the stored key properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->