### PR TITLE
fix(security): explicitly disable HTML rendering in agent output

### DIFF
--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -7,6 +7,15 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import ScorecardOutput from './ScorecardOutput'
 import VoiceOutput from './VoiceOutput'
 
+/**
+ * XSS Protection:
+ * - ReactMarkdown v9 by default does NOT render raw HTML or script tags
+ * - Markdown input is safely escaped; only safe markdown syntax is rendered
+ * - Agent prompts cannot inject <script> or HTML attributes via output
+ * - Code blocks are syntax-highlighted but never evaluated
+ * - Do NOT use dangerouslySetInnerHTML with agent output under any circumstances
+ */
+
 function stripMarkdown(text) {
   if (!text) return ''
   return text
@@ -128,6 +137,7 @@ export default function OutputRenderer({ content, outputType, agentName, systemP
         ) : outputType === 'markdown' ? (
           <div className="markdown-output text-sm dark:text-text-primary text-gray-900">
             <ReactMarkdown
+              skipHtml={true}
               remarkPlugins={[remarkGfm]}
               components={{
                 code({ node, className, children, ...props }) {


### PR DESCRIPTION
## Problem
Agent output rendered through react-markdown lacked explicit XSS protection configuration. While the library safely escapes HTML by default, the component should explicitly document and enforce this protection against prompt injection attacks.

## Fix
- Added skipHtml={true} to ReactMarkdown for explicit HTML disabling
- Added comprehensive XSS protection documentation
- Clarified that agent prompts cannot inject script tags

## Defense-in-Depth
- React-markdown v9 does NOT render raw HTML by default
- Added explicit skipHtml flag (defense-in-depth)
- Code blocks are syntax-highlighted but never evaluated
- Documented restriction against dangerouslySetInnerHTML with agent output

Fixes #732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown output now ignores embedded HTML, preventing raw HTML and script content from being rendered.
  * Code blocks continue to display as formatted text with syntax highlighting instead of being executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->