### PR TITLE
fix: persist agent run ratings and surface aggregate on agent cards

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom";
 import * as Icons from "lucide-react";
 import { ArrowRight, FolderPlus, Star } from "lucide-react";
 import { useFavorites } from "../lib/useFavorites";
+import { useAgentRatings } from "../lib/useAgentRatings";
 import { useState } from "react";
 import CollectionPicker from "./CollectionPicker";
 
@@ -61,8 +62,10 @@ export default function AgentCard({ agent }) {
 const prov = providerColors[agent?.provider] || providerColors.any;
 const provLabel = providerLabels[agent?.provider] || agent?.provider || "Any Provider";
   const { isFavorite, toggleFavorite } = useFavorites();
+  const { getRating } = useAgentRatings();
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const favorited = isFavorite(agent.id);
+  const { total: ratingTotal, percentage: ratingPercentage } = getRating(agent.id);
 
   const handleFavorite = (e) => {
     e.preventDefault(); // prevent Link navigation
@@ -152,12 +155,24 @@ const provLabel = providerLabels[agent?.provider] || agent?.provider || "Any Pro
       </p>
 
       {/* Bottom: provider badge + run link */}
-      <div className="flex items-center justify-between mt-auto">
-        <span
-          className={`text-[10px] font-medium px-2 py-0.5 rounded-full border ${prov.bg} ${prov.text} ${prov.border}`}
-        >
-          {provLabel}
-        </span>
+<div className="flex items-center justify-between mt-auto">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`text-[10px] font-medium px-2 py-0.5 rounded-full border ${prov.bg} ${prov.text} ${prov.border}`}
+          >
+            {provLabel}
+          </span>
+          {ratingTotal > 0 && (
+            <span
+              className="text-[10px] font-medium px-2 py-0.5 rounded-full border
+              bg-gray-100 text-gray-500 border-gray-200
+              dark:bg-surface-input dark:text-text-muted dark:border-border"
+              title={`${ratingPercentage}% positive from ${ratingTotal} rating${ratingTotal === 1 ? "" : "s"}`}
+            >
+              👍 {ratingPercentage}%
+            </span>
+          )}
+        </div>
         <span className="flex items-center gap-1 text-xs font-medium text-accent opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-all duration-300 transform translate-x-2 group-hover:translate-x-0 group-focus-visible:translate-x-0">
           Run <ArrowRight size={12} className="transition-transform duration-300 transform group-hover:translate-x-1 group-focus-visible:translate-x-1" />
         </span>

--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -1059,7 +1059,7 @@ const handleRun = async () => {
   </div>
 )}
           </ErrorBoundary>
-          <RunRating />
+          <RunRating agentId={agent.id} />
           <div className="flex justify-end">
             <button
               onClick={handleSendToWorkflow}

--- a/src/components/RunRating.jsx
+++ b/src/components/RunRating.jsx
@@ -1,14 +1,21 @@
 import { useState } from 'react'
 import { ThumbsUp, ThumbsDown } from 'lucide-react'
+import { useAgentRatings } from '../lib/useAgentRatings'
 
-export default function RunRating() {
-  const [rating, setRating] = useState(null) // 'up' | 'down' | null
-  const [submitted, setSubmitted] = useState(false)
+export default function RunRating({ agentId }) {
+    const [rating, setRating] = useState(null) // 'up' | 'down' | null
+    const [submitted, setSubmitted] = useState(false)
+    const { rateAgent } = useAgentRatings()
 
   const handleRate = (value) => {
     setRating(value)
     setSubmitted(true)
     // In a real app, send to analytics or database here
+    if (agentId) {
+        rateAgent(agentId, value)
+    } else if (import.meta.env.DEV) {
+        console.warn('RunRating: no agentId provided — this rating will not be saved.')
+    }
   }
 
   if (submitted) {

--- a/src/lib/useAgentRatings.js
+++ b/src/lib/useAgentRatings.js
@@ -1,0 +1,80 @@
+
+import { useState, useCallback, useEffect } from 'react'
+ 
+const STORAGE_KEY = 'ila_ratings'
+ 
+function loadRatings() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : {}
+  } catch {
+    return {}
+  }
+}
+ 
+function saveRatings(ratings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ratings))
+}
+ 
+// Global listeners so multiple components stay in sync
+const listeners = new Set()
+function notify() {
+  listeners.forEach((fn) => fn())
+}
+ 
+/**
+ * Hook to manage per-agent run ratings (👍/👎), persisted in localStorage.
+ * Mirrors the useFavorites.js pattern: all components using this hook
+ * stay in sync via a shared listener set.
+ *
+ * Storage shape: { [agentId]: { up: number, down: number } }
+ */
+export function useAgentRatings() {
+  const [ratings, setRatings] = useState(loadRatings)
+ 
+  // Subscribe to cross-component updates
+  useEffect(() => {
+    const sync = () => setRatings(loadRatings())
+    listeners.add(sync)
+    return () => listeners.delete(sync)
+  }, [])
+ 
+  /**
+   * Record a rating for a given agent.
+   * @param {string} agentId
+   * @param {'up' | 'down'} value
+   */
+  const rateAgent = useCallback((agentId, value) => {
+    if (!agentId || (value !== 'up' && value !== 'down')) return
+ 
+    const current = loadRatings()
+    const existing = current[agentId] || { up: 0, down: 0 }
+    const next = {
+      ...current,
+      [agentId]: {
+        ...existing,
+        [value]: existing[value] + 1,
+      },
+    }
+    saveRatings(next)
+    setRatings(next)
+    notify()
+  }, [])
+ 
+  /**
+   * Get the aggregate rating for a given agent.
+   * @param {string} agentId
+   * @returns {{ up: number, down: number, total: number, percentage: number | null }}
+   */
+  const getRating = useCallback(
+    (agentId) => {
+      const entry = ratings[agentId] || { up: 0, down: 0 }
+      const total = entry.up + entry.down
+      const percentage = total > 0 ? Math.round((entry.up / total) * 100) : null
+      return { up: entry.up, down: entry.down, total, percentage }
+    },
+    [ratings],
+  )
+ 
+  return { ratings, rateAgent, getRating }
+}

--- a/src/lib/useAgentRatings.js
+++ b/src/lib/useAgentRatings.js
@@ -13,7 +13,13 @@ function loadRatings() {
 }
  
 function saveRatings(ratings) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(ratings))
+  //localStorage.setItem(STORAGE_KEY, JSON.stringify(ratings))
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ratings))
+   } catch {
+    // localStorage can throw in private browsing or when storage quota
+    // is full — fail silently rather than breaking the rating flow.
+    }
 }
  
 // Global listeners so multiple components stay in sync

--- a/src/pages/WorkflowRunner.jsx
+++ b/src/pages/WorkflowRunner.jsx
@@ -538,7 +538,7 @@ export default function WorkflowRunner() {
                       outputType={step.agent?.outputType ?? 'text'}
                       agentName={step.agentName}
                     />
-                    <RunRating />
+                    <RunRating agentId={step.agent?.id} />
                   </div>
                 )}
 


### PR DESCRIPTION
## What does this PR do?
<!-- Describe your changes clearly -->
RunRating (the 👍/👎 prompt shown after every agent run) collected feedback but never persisted it — the vote lived in local component state only and vanished the moment the component unmounted. Both call sites rendered <RunRating /> with no props at all, so there was also no way to associate a rating with a specific agent even if it had been saved.

This PR wires it up properly:


Adds src/lib/useAgentRatings.js, a localStorage-backed hook mirroring the existing useFavorites.js pattern (same cross-component sync approach). Stores { [agentId]: { up, down } } under ila_ratings.
RunRating now accepts an agentId prop and calls rateAgent() on click instead of discarding the vote.
AgentRunner.jsx and WorkflowRunner.jsx now pass the relevant agentId through to RunRating.
AgentCard.jsx shows a 👍 XX% badge next to the provider badge, only once an agent has received at least one rating.


No new dependencies, no backend — fully consistent with the existing client-side/localStorage architecture already used for favorites and history.

Note: unrelated to the marketplace listing star-ratings (marketplace.js) that recently landed — that rates published listings; this rates individual run outputs, regardless of whether the agent is published.

Closes #675

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
<!-- Add screenshots here -->
<img width="1119" height="903" alt="Screenshot 2026-07-09 152050" src="https://github.com/user-attachments/assets/4b5a1566-8850-407f-97e8-c41a936f7783" />
<img width="845" height="220" alt="Screenshot 2026-07-09 152157" src="https://github.com/user-attachments/assets/6e2b65e1-d782-4c5f-8bae-bd88d4f6a146" />
<img width="878" height="427" alt="Screenshot 2026-07-09 152232" src="https://github.com/user-attachments/assets/41e9d04c-4db0-4964-a3f6-e16352a1bd01" />
<img width="1402" height="719" alt="Screenshot 2026-07-09 160045" src="https://github.com/user-attachments/assets/5cec7c21-6fd1-4639-91e6-3e603048e97b" />


Rating badge on AgentCard (bottom-right, next to provider badge), only shown once an agent has ≥1 rating:

👍 100% — small pill, same style/sizing as the existing provider badge, light/dark theme aware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visible positive-rating summaries to agent cards (including a thumbs-up indicator with percentage and details when available).
  * Ratings in runner views are now linked to the relevant agent context.
  * Ratings are persisted locally so they remain available across sessions.

* **Bug Fixes**
  * Ensured rating submissions are consistently recorded and immediately reflected across the related UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->