### PR TITLE
feat: enable Enter key navigation in suite questionnaire

### DIFF
--- a/src/components/SuiteWizard.jsx
+++ b/src/components/SuiteWizard.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   ArrowLeft, ArrowRight, SkipForward, Sparkles,
@@ -35,6 +35,23 @@ export default function SuiteWizard({ suite, onBack }) {
   const [tagCounts, setTagCounts] = useState({})
   const [answeredCount, setAnsweredCount] = useState(0)
   const [showResults, setShowResults] = useState(false)
+  useEffect(() => {
+  const handleKeyDown = (event) => {
+    if (event.key !== 'Enter') return
+
+    if (selected == null) return
+
+    event.preventDefault()
+
+    handleNext()
+  }
+
+  window.addEventListener('keydown', handleKeyDown)
+
+  return () => {
+    window.removeEventListener('keydown', handleKeyDown)
+  }
+}, [selected, step])
 
   // ── Helpers
 

--- a/src/components/SuiteWizard.jsx
+++ b/src/components/SuiteWizard.jsx
@@ -35,21 +35,37 @@ export default function SuiteWizard({ suite, onBack }) {
   const [tagCounts, setTagCounts] = useState({})
   const [answeredCount, setAnsweredCount] = useState(0)
   const [showResults, setShowResults] = useState(false)
+  
   useEffect(() => {
   const handleKeyDown = (event) => {
-    if (event.key !== 'Enter') return
+    if (event.key !== "Enter") return
+
+    const active = document.activeElement
+
+    if (active) {
+      const tag = active.tagName
+
+      const isInteractive =
+        ["BUTTON", "INPUT", "TEXTAREA", "SELECT", "A"].includes(tag)
+
+      const isOptionButton =
+        active.dataset.option === "true"
+
+      if (isInteractive && !isOptionButton) {
+        return
+      }
+    }
 
     if (selected == null) return
 
     event.preventDefault()
-
     handleNext()
   }
 
-  window.addEventListener('keydown', handleKeyDown)
+  window.addEventListener("keydown", handleKeyDown)
 
   return () => {
-    window.removeEventListener('keydown', handleKeyDown)
+    window.removeEventListener("keydown", handleKeyDown)
   }
 }, [selected, step])
 
@@ -259,6 +275,7 @@ export default function SuiteWizard({ suite, onBack }) {
         {question.options.map((opt, idx) => (
           <button
             key={idx}
+            data-option="true"
             onClick={() => setSelected(idx)}
             className={`text-left px-4 py-3.5 rounded-xl border text-sm font-medium transition-all duration-150
               ${selected === idx

--- a/src/components/SuiteWizard.jsx
+++ b/src/components/SuiteWizard.jsx
@@ -41,7 +41,7 @@ export default function SuiteWizard({ suite, onBack }) {
   
   useEffect(() => {
   const handleKeyDown = (event) => {
-    if (event.key !== "Enter") return
+    if (event.key !== "Enter" || event.repeat) return
 
     const active = document.activeElement
 
@@ -51,15 +51,16 @@ export default function SuiteWizard({ suite, onBack }) {
       const isInteractive =
         ["BUTTON", "INPUT", "TEXTAREA", "SELECT", "A"].includes(tag)
 
-      const isOptionButton =
-        active.dataset.option === "true"
+      const isSelectedOptionButton =
+  active.dataset.option === "true" &&
+  Number(active.dataset.index) === answers[step]
 
-      if (isInteractive && !isOptionButton) {
-        return
-      }
+if (isInteractive && !isSelectedOptionButton) {
+  return
+}
     }
 
-    if (selected == null) return
+    if (answers[step] == null) return
 
     event.preventDefault()
     handleNext()
@@ -70,7 +71,7 @@ export default function SuiteWizard({ suite, onBack }) {
   return () => {
     window.removeEventListener("keydown", handleKeyDown)
   }
-}, [selected, step])
+}, [answers, step])
 
   // ── Helpers
 
@@ -292,6 +293,7 @@ export default function SuiteWizard({ suite, onBack }) {
           <button
             key={idx}
 data-option="true"
+data-index={idx}
 onClick={() => {
   const updated = [...answers]
   updated[step] = idx


### PR DESCRIPTION
## What does this PR do?

Fixes #758

### Changes made
- Added Enter key support to advance to the next question.
- Preserved existing Next button behavior.
- Prevented navigation when no option is selected.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other

## Testing
- [x] Verified pressing Enter advances to the next question after selecting an option.
- [x] Verified pressing Enter without selecting an option does nothing.
- [x] Confirmed existing mouse navigation still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved keyboard support to the suite wizard: after selecting an answer, press **Enter** to proceed just like the **Next** button.

* **Bug Fixes**
  * Prevented unintended default behavior when pressing **Enter**, avoiding accidental submissions or navigation when focus is on other interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->