### PR TITLE
feat: add agent collections and workspace organization (#777)

### DIFF
--- a/src/components/AgentCard.jsx
+++ b/src/components/AgentCard.jsx
@@ -64,6 +64,11 @@ const provLabel = providerLabels[agent?.provider] || agent?.provider || "Any Pro
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const favorited = isFavorite(agent.id);
 
+  const handleDragStart = (event) => {
+    event.dataTransfer.setData('text/plain', agent.id);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
   const handleFavorite = (e) => {
     e.preventDefault(); // prevent Link navigation
     e.stopPropagation();
@@ -80,7 +85,9 @@ const provLabel = providerLabels[agent?.provider] || agent?.provider || "Any Pro
     <>
     <Link
       to={`/agent/${agent.id}`}
-      className="premium-hover-card group block rounded-lg border p-4 bg-white border-gray-200 
+      draggable
+      onDragStart={handleDragStart}
+      className="premium-hover-card group block rounded-lg border p-4 bg-white border-gray-200 cursor-grab
       dark:bg-surface-card dark:border-border
       transition-all duration-500 
       hover:[transform:perspective(1000px)_rotateX(6deg)_rotateY(-6deg)_translateY(-8px)] 

--- a/src/components/CollectionPicker.jsx
+++ b/src/components/CollectionPicker.jsx
@@ -1,11 +1,16 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { FolderPlus, Plus, X } from 'lucide-react'
-import { MAX_COLLECTIONS, useCollections } from '../lib/useCollections'
+import { DEFAULT_COLLECTION_ID, MAX_COLLECTIONS, useCollections } from '../lib/useCollections'
 
 export default function CollectionPicker({ agentId, onClose }) {
   const { collections, createCollection, addAgentToCollection, isAgentInCollection } = useCollections()
   const [name, setName] = useState('')
   const [message, setMessage] = useState('')
+
+  const visibleCollections = useMemo(
+    () => collections.filter((collection) => collection.id !== DEFAULT_COLLECTION_ID),
+    [collections]
+  )
 
   const handleCreate = () => {
     const result = createCollection(name)
@@ -29,17 +34,17 @@ export default function CollectionPicker({ agentId, onClose }) {
         </div>
         <div className="space-y-4 p-5">
           <div className="space-y-2">
-            {collections.length === 0 ? <p className="text-sm text-gray-500 dark:text-text-secondary">No collections yet.</p> : collections.map((collection) => {
+            {visibleCollections.length === 0 ? <p className="text-sm text-gray-500 dark:text-text-secondary">No collections yet.</p> : visibleCollections.map((collection) => {
               const alreadyAdded = isAgentInCollection(collection.id, agentId)
               return <button key={collection.id} type="button" onClick={() => handleAdd(collection)} disabled={alreadyAdded} className="flex w-full items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-left text-sm transition hover:border-accent/50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border dark:hover:border-accent/50"><span className="font-medium text-gray-800 dark:text-text-primary">{collection.name}</span><span className="text-xs text-gray-500 dark:text-text-muted">{alreadyAdded ? 'Already added' : `${collection.agentIds.length} agents`}</span></button>
             })}
           </div>
           <div className="flex gap-2 border-t border-gray-100 pt-4 dark:border-border">
-            <input value={name} onChange={(event) => setName(event.target.value)} disabled={collections.length >= MAX_COLLECTIONS} className="min-w-0 flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-60 dark:border-border dark:bg-surface-input dark:text-text-primary" placeholder="New collection name" />
-            <button type="button" onClick={handleCreate} disabled={collections.length >= MAX_COLLECTIONS} className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"><Plus size={15} />Create</button>
+            <input value={name} onChange={(event) => setName(event.target.value)} disabled={visibleCollections.length >= MAX_COLLECTIONS} className="min-w-0 flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-accent focus:ring-1 focus:ring-accent disabled:opacity-60 dark:border-border dark:bg-surface-input dark:text-text-primary" placeholder="New collection name" />
+            <button type="button" onClick={handleCreate} disabled={visibleCollections.length >= MAX_COLLECTIONS} className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"><Plus size={15} />Create</button>
           </div>
           {message && <p className="rounded-lg border border-accent/20 bg-accent/10 px-3 py-2 text-sm text-accent">{message}</p>}
-          {collections.length >= MAX_COLLECTIONS && <p className="text-xs text-gray-500 dark:text-text-muted">You can create up to {MAX_COLLECTIONS} collections.</p>}
+          {visibleCollections.length >= MAX_COLLECTIONS && <p className="text-xs text-gray-500 dark:text-text-muted">You can create up to {MAX_COLLECTIONS} collections.</p>}
         </div>
       </div>
     </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { Link, NavLink, useLocation } from 'react-router-dom'
 import * as Icons from 'lucide-react'
 import { loadAllAgents } from '../agents/registry'
-import { useCollections } from '../lib/useCollections'
+import { DEFAULT_COLLECTION_ID, useCollections } from '../lib/useCollections'
 
 const SIDEBAR_CATEGORY_STORAGE_KEY = 'sidebar-category-collapsed-state'
 
@@ -21,7 +21,8 @@ export default function Sidebar({ open, onClose }) {
   })
   const [searchExpandedCategories, setSearchExpandedCategories] = useState({})
   const [agents, setAgents] = useState([])
-  const { collections } = useCollections()
+  const [feedback, setFeedback] = useState('')
+  const { collections, moveAgentToCollection } = useCollections()
   const location = useLocation()
 
   useEffect(() => {
@@ -48,6 +49,7 @@ export default function Sidebar({ open, onClose }) {
     ? location.pathname.split('/agent/')[1]
     : null
 
+  const activeCollectionId = new URLSearchParams(location.search).get('collection')
   const activeAgent = agents.find((a) => a.id === currentAgentId)
   const activeCategory = activeAgent ? activeAgent.category : null
 
@@ -89,6 +91,28 @@ export default function Sidebar({ open, onClose }) {
       }))
     }
   }
+
+  const handleCollectionDrop = (event, collectionId) => {
+    event.preventDefault()
+    const agentId = event.dataTransfer.getData('text/plain')
+    if (!agentId) return
+
+    const collection = collections.find((item) => item.id === collectionId)
+    const result = moveAgentToCollection(agentId, collectionId)
+
+    setFeedback(
+      result.ok
+        ? `Moved to ${collection?.name || 'the selected collection'}.`
+        : result.error
+    )
+
+    window.setTimeout(() => setFeedback(''), 2200)
+  }
+
+  const customCollections = collections.filter(
+    (collection) => collection.id !== DEFAULT_COLLECTION_ID
+  )
+  const allAgentsCount = agents.length
 
   return (
     <>
@@ -180,9 +204,15 @@ export default function Sidebar({ open, onClose }) {
             <div className="mb-1 flex items-center justify-between px-1.5 text-[10px] font-bold uppercase tracking-widest text-gray-500 dark:text-text-muted">
               <span>Collections</span>
               <span className="rounded-full bg-accent/15 px-1.5 py-0.5 text-[9px] text-accent">
-                {collections.length}
+                {customCollections.length}
               </span>
             </div>
+
+            {feedback && (
+              <div className="mb-2 rounded-md border border-accent/20 bg-accent/10 px-2 py-1.5 text-[11px] text-accent">
+                {feedback}
+              </div>
+            )}
 
             <NavLink
               to="/collections"
@@ -200,28 +230,45 @@ export default function Sidebar({ open, onClose }) {
               <span className="truncate">All Collections</span>
             </NavLink>
 
-            {collections.slice(0, 10).map((collection) => (
-              <NavLink
+            <Link
+              to="/"
+              onClick={onClose}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => handleCollectionDrop(event, DEFAULT_COLLECTION_ID)}
+              className={`relative mb-0.5 flex items-center gap-2.5 rounded-md py-1.5 pl-2 pr-2 text-[12px] font-medium transition-all duration-200 group
+                ${
+                  location.pathname === '/' && !activeCollectionId
+                    ? 'bg-accent/15 text-accent font-semibold shadow-sm'
+                    : 'text-gray-700 hover:bg-gray-150/50 hover:text-gray-950 dark:text-text-secondary dark:hover:bg-white/10 dark:hover:text-text-primary'
+                }`}
+            >
+              <Icons.FolderInput size={14} className="flex-shrink-0" />
+              <span className="min-w-0 flex-1 truncate">All Agents</span>
+              <span className="rounded-full bg-accent/15 px-1.5 py-0.5 text-[9px] font-bold text-accent">
+                {allAgentsCount}
+              </span>
+            </Link>
+
+            {customCollections.map((collection) => (
+              <Link
                 key={collection.id}
-                to={`/collections/${collection.id}`}
+                to={collection.id === DEFAULT_COLLECTION_ID ? '/' : `/?collection=${collection.id}`}
                 onClick={onClose}
-                className={({ isActive }) =>
-                  `relative flex items-center gap-2.5 rounded-md py-1.5 pl-2 pr-2 text-[12px] font-medium transition-all duration-200 group
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => handleCollectionDrop(event, collection.id)}
+                className={`relative flex items-center gap-2.5 rounded-md py-1.5 pl-2 pr-2 text-[12px] font-medium transition-all duration-200 group
                   ${
-                    isActive
+                    location.pathname === '/' && activeCollectionId === collection.id
                       ? 'bg-accent/15 text-accent font-semibold shadow-sm'
                       : 'text-gray-700 hover:bg-gray-150/50 hover:text-gray-950 dark:text-text-secondary dark:hover:bg-white/10 dark:hover:text-text-primary'
-                  }`
-                }
+                  }`}
               >
                 <Icons.Folder size={14} className="flex-shrink-0" />
-                <span className="min-w-0 flex-1 truncate">
-                  {collection.name}
-                </span>
+                <span className="min-w-0 flex-1 truncate">{collection.name}</span>
                 <span className="rounded-full bg-accent/15 px-1.5 py-0.5 text-[9px] font-bold text-accent">
                   {collection.agentIds.length}
                 </span>
-              </NavLink>
+              </Link>
             ))}
           </div>
 

--- a/src/lib/useCollections.js
+++ b/src/lib/useCollections.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 export const MAX_COLLECTIONS = 10
 export const MAX_AGENTS_PER_COLLECTION = 15
 export const COLLECTIONS_STORAGE_KEY = 'ila_agent_collections'
+export const DEFAULT_COLLECTION_ID = 'all-agents'
 
 const listeners = new Set()
 
@@ -18,11 +19,28 @@ function createId() {
   return `collection-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+function createDefaultCollection() {
+  const now = new Date().toISOString()
+
+  return {
+    id: DEFAULT_COLLECTION_ID,
+    name: 'All Agents',
+    agentIds: [],
+    createdAt: now,
+    updatedAt: now,
+    isDefault: true,
+  }
+}
+
 function normalizeCollection(collection) {
   if (!collection || typeof collection !== 'object') return null
 
+  const isDefaultCollection =
+    collection.id === DEFAULT_COLLECTION_ID || Boolean(collection.isDefault)
   const name = typeof collection.name === 'string' ? collection.name.trim() : ''
-  if (!name) return null
+  const normalizedName = isDefaultCollection ? 'All Agents' : name
+
+  if (!normalizedName && !isDefaultCollection) return null
 
   const now = new Date().toISOString()
   const agentIds = Array.isArray(collection.agentIds)
@@ -40,38 +58,50 @@ function normalizeCollection(collection) {
       typeof collection.id === 'string' && collection.id.trim()
         ? collection.id.trim()
         : createId(),
-    name,
+    name: normalizedName,
     agentIds,
     createdAt:
       typeof collection.createdAt === 'string' ? collection.createdAt : now,
     updatedAt:
       typeof collection.updatedAt === 'string' ? collection.updatedAt : now,
+    isDefault: isDefaultCollection,
   }
 }
 
+function buildCollections(collections) {
+  const normalized = Array.isArray(collections)
+    ? collections.map(normalizeCollection).filter(Boolean)
+    : []
+
+  const defaultCollection =
+    normalized.find((collection) => collection.id === DEFAULT_COLLECTION_ID) ||
+    createDefaultCollection()
+
+  const customCollections = normalized.filter(
+    (collection) => collection.id !== DEFAULT_COLLECTION_ID
+  )
+
+  const uniqueCollections = [defaultCollection, ...customCollections].filter(
+    (collection, index, all) =>
+      all.findIndex((item) => item.id === collection.id) === index
+  )
+
+  return uniqueCollections.slice(0, MAX_COLLECTIONS + 1)
+}
+
 export function loadCollections() {
-  if (typeof localStorage === 'undefined') return []
+  if (typeof localStorage === 'undefined') return [createDefaultCollection()]
 
   try {
     const raw = localStorage.getItem(COLLECTIONS_STORAGE_KEY)
-    if (!raw) return []
+    if (!raw) return [createDefaultCollection()]
 
     const parsed = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return []
+    if (!Array.isArray(parsed)) return [createDefaultCollection()]
 
-    const seenIds = new Set()
-
-    return parsed
-      .map(normalizeCollection)
-      .filter(Boolean)
-      .filter((collection) => {
-        if (seenIds.has(collection.id)) return false
-        seenIds.add(collection.id)
-        return true
-      })
-      .slice(0, MAX_COLLECTIONS)
+    return buildCollections(parsed)
   } catch {
-    return []
+    return [createDefaultCollection()]
   }
 }
 
@@ -79,8 +109,8 @@ export function saveCollections(collections) {
   if (typeof localStorage === 'undefined') return
 
   const normalized = Array.isArray(collections)
-    ? collections.map(normalizeCollection).filter(Boolean).slice(0, MAX_COLLECTIONS)
-    : []
+    ? buildCollections(collections)
+    : [createDefaultCollection()]
 
   localStorage.setItem(COLLECTIONS_STORAGE_KEY, JSON.stringify(normalized))
 }
@@ -130,27 +160,48 @@ export function useCollections() {
       }
 
       return runMutation((current) => {
-        if (current.length >= MAX_COLLECTIONS) {
+        const customCollections = current.filter(
+          (collection) => collection.id !== DEFAULT_COLLECTION_ID
+        )
+
+        if (customCollections.length >= MAX_COLLECTIONS) {
           return {
             ok: false,
             error: `You can create up to ${MAX_COLLECTIONS} collections.`,
           }
         }
 
-        const now = new Date().toISOString()
+        const duplicateName = customCollections.some(
+          (collection) =>
+            collection.name.toLowerCase() === trimmedName.toLowerCase()
+        )
 
+        if (duplicateName) {
+          return {
+            ok: false,
+            error: 'A collection with that name already exists.',
+          }
+        }
+
+        const now = new Date().toISOString()
         const collection = {
           id: createId(),
           name: trimmedName,
           agentIds: [],
           createdAt: now,
           updatedAt: now,
+          isDefault: false,
         }
 
         return {
           ok: true,
           collection,
-          collections: [collection, ...current],
+          collections: [
+            current.find((item) => item.id === DEFAULT_COLLECTION_ID) ||
+              createDefaultCollection(),
+            collection,
+            ...customCollections,
+          ],
         }
       })
     },
@@ -159,12 +210,47 @@ export function useCollections() {
 
   const deleteCollection = useCallback(
     (collectionId) => {
-      return runMutation((current) => ({
-        ok: true,
-        collections: current.filter(
-          (collection) => collection.id !== collectionId
-        ),
-      }))
+      if (collectionId === DEFAULT_COLLECTION_ID) {
+        return { ok: false, error: 'The default collection cannot be deleted.' }
+      }
+
+      return runMutation((current) => {
+        const collectionToDelete = current.find((item) => item.id === collectionId)
+
+        if (!collectionToDelete) {
+          return { ok: false, error: 'Collection not found.' }
+        }
+
+        const defaultCollection = current.find(
+          (item) => item.id === DEFAULT_COLLECTION_ID
+        ) || createDefaultCollection()
+        const now = new Date().toISOString()
+
+        return {
+          ok: true,
+          collections: current
+            .filter((collection) => collection.id !== collectionId)
+            .map((collection) =>
+              collection.id === DEFAULT_COLLECTION_ID
+                ? {
+                    ...collection,
+                    agentIds: [
+                      ...new Set([...collection.agentIds, ...collectionToDelete.agentIds]),
+                    ],
+                    updatedAt: now,
+                  }
+                : collection
+            )
+            .filter((collection, index, all) =>
+              all.findIndex((item) => item.id === collection.id) === index
+            )
+            .map((collection) =>
+              collection.id === DEFAULT_COLLECTION_ID
+                ? { ...defaultCollection, ...collection, updatedAt: now }
+                : collection
+            ),
+        }
+      })
     },
     [runMutation]
   )
@@ -177,18 +263,40 @@ export function useCollections() {
         return { ok: false, error: 'Collection name is required.' }
       }
 
-      return runMutation((current) => ({
-        ok: true,
-        collections: current.map((collection) =>
-          collection.id === collectionId
-            ? {
-                ...collection,
-                name: trimmedName,
-                updatedAt: new Date().toISOString(),
-              }
-            : collection
-        ),
-      }))
+      if (collectionId === DEFAULT_COLLECTION_ID) {
+        return { ok: false, error: 'The default collection cannot be renamed.' }
+      }
+
+      return runMutation((current) => {
+        const customCollections = current.filter(
+          (collection) => collection.id !== DEFAULT_COLLECTION_ID
+        )
+        const duplicateName = customCollections.some(
+          (collection) =>
+            collection.id !== collectionId &&
+            collection.name.toLowerCase() === trimmedName.toLowerCase()
+        )
+
+        if (duplicateName) {
+          return {
+            ok: false,
+            error: 'A collection with that name already exists.',
+          }
+        }
+
+        return {
+          ok: true,
+          collections: current.map((collection) =>
+            collection.id === collectionId
+              ? {
+                  ...collection,
+                  name: trimmedName,
+                  updatedAt: new Date().toISOString(),
+                }
+              : collection
+          ),
+        }
+      })
     },
     [runMutation]
   )
@@ -199,6 +307,12 @@ export function useCollections() {
         return { ok: false, error: 'Collection and agent are required.' }
       }
 
+      const normalizedAgentId = typeof agentId === 'string' ? agentId.trim() : ''
+
+      if (!normalizedAgentId) {
+        return { ok: false, error: 'Agent is required.' }
+      }
+
       return runMutation((current) => {
         const collection = current.find((item) => item.id === collectionId)
 
@@ -206,7 +320,7 @@ export function useCollections() {
           return { ok: false, error: 'Collection not found.' }
         }
 
-        if (collection.agentIds.includes(agentId)) {
+        if (collection.agentIds.includes(normalizedAgentId)) {
           return {
             ok: false,
             error: 'This agent is already in that collection.',
@@ -220,17 +334,29 @@ export function useCollections() {
           }
         }
 
+        const now = new Date().toISOString()
+
         return {
           ok: true,
-          collections: current.map((item) =>
-            item.id === collectionId
-              ? {
-                  ...item,
-                  agentIds: [...item.agentIds, agentId],
-                  updatedAt: new Date().toISOString(),
-                }
-              : item
-          ),
+          collections: current.map((item) => {
+            if (item.id === collectionId) {
+              return {
+                ...item,
+                agentIds: [...new Set([...item.agentIds, normalizedAgentId])],
+                updatedAt: now,
+              }
+            }
+
+            if (item.agentIds.includes(normalizedAgentId)) {
+              return {
+                ...item,
+                agentIds: item.agentIds.filter((id) => id !== normalizedAgentId),
+                updatedAt: now,
+              }
+            }
+
+            return item
+          }),
         }
       })
     },
@@ -259,9 +385,35 @@ export function useCollections() {
     [runMutation]
   )
 
+  const moveAgentToCollection = useCallback(
+    (agentId, collectionId) => {
+      if (!collectionId || !agentId) {
+        return { ok: false, error: 'Collection and agent are required.' }
+      }
+
+      return addAgentToCollection(collectionId, agentId)
+    },
+    [addAgentToCollection]
+  )
+
   const getCollectionById = useCallback(
     (collectionId) =>
       collections.find((collection) => collection.id === collectionId),
+    [collections]
+  )
+
+  const getAgentCollectionId = useCallback(
+    (agentId) => {
+      const normalizedAgentId = typeof agentId === 'string' ? agentId.trim() : ''
+
+      if (!normalizedAgentId) return DEFAULT_COLLECTION_ID
+
+      const collection = collections.find(
+        (item) => item.id !== DEFAULT_COLLECTION_ID && item.agentIds.includes(normalizedAgentId)
+      )
+
+      return collection ? collection.id : DEFAULT_COLLECTION_ID
+    },
     [collections]
   )
 
@@ -278,7 +430,9 @@ export function useCollections() {
     renameCollection,
     addAgentToCollection,
     removeAgentFromCollection,
+    moveAgentToCollection,
     getCollectionById,
+    getAgentCollectionId,
     isAgentInCollection,
   }
 }

--- a/src/pages/CollectionsPage.jsx
+++ b/src/pages/CollectionsPage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { Edit3, FolderPlus, Plus, Trash2 } from 'lucide-react'
 import CollectionModal from '../components/CollectionModal'
 import { useAgents } from '../lib/useAgents'
-import { MAX_COLLECTIONS, useCollections } from '../lib/useCollections'
+import { DEFAULT_COLLECTION_ID, MAX_COLLECTIONS, useCollections } from '../lib/useCollections'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 export default function CollectionsPage() {
@@ -14,6 +14,10 @@ export default function CollectionsPage() {
   const [name, setName] = useState('')
   const [error, setError] = useState('')
 
+  const customCollections = useMemo(
+    () => collections.filter((collection) => collection.id !== DEFAULT_COLLECTION_ID),
+    [collections]
+  )
   const agentMap = useMemo(() => new Map(agents.map((agent) => [agent.id, agent])), [agents])
   const openCreate = () => { setModal('create'); setName(''); setError('') }
   const submitCreate = (event) => { event.preventDefault(); const result = createCollection(name); if (!result.ok) return setError(result.error); setModal(null) }
@@ -40,11 +44,11 @@ export default function CollectionsPage() {
   return <div className="animate-fade-in space-y-8">
     <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div><h1 className="text-3xl font-bold text-gray-900 dark:text-text-primary">Collections</h1><p className="mt-2 text-sm text-gray-500 dark:text-text-secondary">Create custom groups of agents for your workflows.</p></div>
-      <button onClick={openCreate} disabled={collections.length >= MAX_COLLECTIONS} className="inline-flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"><Plus size={16} />New Collection</button>
+      <button onClick={openCreate} disabled={customCollections.length >= MAX_COLLECTIONS} className="inline-flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"><Plus size={16} />New Collection</button>
     </div>
 
-    {collections.length === 0 ? <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-border dark:bg-surface-card"><div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-accent/10 text-accent"><FolderPlus size={24} /></div><h2 className="text-lg font-semibold text-gray-900 dark:text-text-primary">No collections yet</h2><p className="mx-auto mt-2 max-w-md text-sm text-gray-500 dark:text-text-secondary">Start by creating a collection, then add agents from the agent cards.</p><button onClick={openCreate} className="mt-5 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent-hover">Create Collection</button></div> : <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {collections.map((collection) => {
+    {customCollections.length === 0 ? <div className="rounded-2xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-border dark:bg-surface-card"><div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-accent/10 text-accent"><FolderPlus size={24} /></div><h2 className="text-lg font-semibold text-gray-900 dark:text-text-primary">No collections yet</h2><p className="mx-auto mt-2 max-w-md text-sm text-gray-500 dark:text-text-secondary">Start by creating a collection, then add agents from the agent cards.</p><button onClick={openCreate} className="mt-5 rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-accent-hover">Create Collection</button></div> : <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {customCollections.map((collection) => {
         return <article key={collection.id} className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-accent/40 hover:shadow-lg dark:border-border dark:bg-surface-card">
           <div className="mb-4 flex items-start justify-between gap-3"><div className="flex items-center gap-3"><div className="rounded-lg bg-accent/10 p-2 text-accent"><FolderPlus size={20} /></div><div><h2 className="font-semibold text-gray-900 dark:text-text-primary">{collection.name}</h2><p className="text-xs text-gray-500 dark:text-text-muted">{collection.agentIds.length} agents</p></div></div></div>
           <p className="min-h-10 text-sm text-gray-500 dark:text-text-secondary">{getPreviewText(collection)}</p>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Bot, Users, Code2, ArrowRight, Github, Search, X, SlidersHorizontal, Star, Heart, Swords, GitBranch, ChevronDown, Lightbulb } from 'lucide-react'
 import AgentCardSkeleton from '../components/AgentCardSkeleton'
 import AgentCard from '../components/AgentCard'
@@ -10,6 +10,7 @@ import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts'
 import { useAgents } from '../lib/useAgents'
 import RecommendationWizardEntry from '../components/recommendation/RecommendationWizardEntry'
+import { DEFAULT_COLLECTION_ID, useCollections } from '../lib/useCollections'
 import RecommendationWizardModal from '../components/recommendation/RecommendationWizardModal'
 import { Link } from "react-router-dom";
 import { getGlobalKeys } from '../lib/globalKeys'
@@ -48,6 +49,8 @@ export default function HomePage() {
   const recommendationWizardReturnFocusRef = useRef(null)
   const [selectedCategory, setSelectedCategory] = useState(null)
   const [selectedProvider, setSelectedProvider] = useState(null)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { collections, getAgentCollectionId } = useCollections()
 
   // ── First-time banner: show only if no global keys saved and not dismissed
   const [showBanner, setShowBanner] = useState(() => {
@@ -180,6 +183,10 @@ export default function HomePage() {
   
   const { favorites } = useFavorites()
   const { history, deleteRun, clearHistory } = useHistory()
+  const activeCollectionId = searchParams.get('collection') || DEFAULT_COLLECTION_ID
+  const selectedCollection = collections.find(
+    (collection) => collection.id === activeCollectionId
+  )
 
   const recentAgents = useMemo(() => {
     const recentIds = JSON.parse(
@@ -210,6 +217,13 @@ export default function HomePage() {
       const matchesProvider = !selectedProvider || provider === selectedProvider
       if (!matchesProvider) return false
 
+      const matchesCollection =
+        activeCollectionId === DEFAULT_COLLECTION_ID
+          ? true
+          : getAgentCollectionId(agent.id) === activeCollectionId
+
+      if (!matchesCollection) return false
+
       if (!q) return true
 
       const searchableText = [
@@ -227,7 +241,7 @@ export default function HomePage() {
 
       return searchableText.includes(q)
     })
-  }, [agents, searchQuery, selectedCategory, selectedProvider])
+  }, [activeCollectionId, agents, getAgentCollectionId, searchQuery, selectedCategory, selectedProvider])
 
   const handleOpenRecommendationWizard = (event) => {
     event?.preventDefault()
@@ -243,7 +257,8 @@ export default function HomePage() {
     navigator.clipboard.writeText(text)
   }
 
-  const showingFiltered = searchQuery.trim() || selectedCategory || selectedProvider
+  const showingFiltered =
+    searchQuery.trim() || selectedCategory || selectedProvider || activeCollectionId !== DEFAULT_COLLECTION_ID
 
   return (
     <div className="animate-fade-in">
@@ -594,10 +609,24 @@ export default function HomePage() {
       {/* Agent Grid */}
       <div className="premium-section flex flex-col lg:flex-row gap-8 mb-8 relative z-0" style={{ animationDelay: '220ms' }}>
         <div className="flex-1">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
-              {showingFiltered ? "Matching Agents" : "Available Agents"}
-            </h2>
+          <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-sm font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
+                {showingFiltered ? 'Matching Agents' : 'Available Agents'}
+              </h2>
+              <span className="inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent/10 px-2.5 py-1 text-[11px] font-semibold text-accent">
+                {activeCollectionId === DEFAULT_COLLECTION_ID ? 'All Agents' : selectedCollection?.name || 'Collection'}
+                {activeCollectionId !== DEFAULT_COLLECTION_ID && (
+                  <button
+                    type="button"
+                    onClick={() => setSearchParams({})}
+                    className="text-[10px] font-medium text-accent/80 hover:text-accent"
+                  >
+                    Show all
+                  </button>
+                )}
+              </span>
+            </div>
             <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-accent/10 text-accent">
               {filteredAgents.length}{" "}{filteredAgents.length === 1 ? "agent" : "agents"}
             </span>
@@ -624,7 +653,9 @@ export default function HomePage() {
               </div>
               <h3 className="text-sm font-semibold dark:text-text-primary text-gray-900 mb-1">No agents found</h3>
               <p className="text-xs dark:text-text-secondary text-gray-500 mb-4">
-                Try adjusting your search or removing category filters
+                {activeCollectionId === DEFAULT_COLLECTION_ID
+                  ? 'Try adjusting your search or removing category filters'
+                  : 'This collection is empty right now. Try switching back to All Agents or moving an agent into it.'}
               </p>
               <div className="flex flex-col items-center gap-2">
                 <button


### PR DESCRIPTION
Closes #777

## What does this PR do?

This PR adds Agent Collections and Custom Workspace Organization to improve agent management.

### Features implemented
- Create custom collections
- Rename collections
- Delete collections
- Persist collections in localStorage
- Drag & Drop agents between collections
- Collection filtering from the sidebar
- Default "All Agents" collection
- Collection assignment from Agent Cards
- Collection management page
- Collection-based agent filtering on the Home page
- Duplicate collection name validation
- Prevent deleting or renaming the default collection
- Improved empty-state handling

## Type of change

- [ ] New agent
- [ ] Bug fix
- [x] UI improvement
- [ ] Documentation
- [x] Other

## Checklist

- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)

Attached below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support for moving agents between collections.
  * Added collection-based filtering on the home page, including active collection names and a “Show all” option.
  * Added an “All Agents” collection that cannot be renamed or deleted.
  * Added success and error feedback for collection moves.

* **Bug Fixes**
  * Improved collection limits, duplicate-name prevention, deletion behavior, and empty-state messaging.
  * Custom collection views now exclude the default “All Agents” collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->