### PR TITLE
feat: Add Export Button to Download Agent Run Logs as JSON or Text

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -1012,6 +1012,7 @@ const handleRun = async () => {
               outputType={agent.outputType}
               agentName={agent.name}
               systemPrompt={customPrompt}
+              userMessage={buildUserMessage()}
             />
             <div className="flex items-center gap-2 mt-3">
   <button

--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -86,6 +86,8 @@ export default function AgentRunner({ agent }) {
   const [versionHistory, setVersionHistory] = useState([]);
   const [playgroundOpen, setPlaygroundOpen] = useState(false);
   const [customPrompt, setCustomPrompt] = useState(agent.systemPrompt);
+  const [lastRunSystemPrompt, setLastRunSystemPrompt] = useState("");
+  const [lastRunUserMessage, setLastRunUserMessage] = useState("");
   const [msgIndex, setMsgIndex] = useState(0);
   const [analyserOpen, setAnalyserOpen] = useState(false);
   const [modelRecommendation, setModelRecommendation] = useState(null);
@@ -258,6 +260,9 @@ const handleRun = async () => {
       },
       ...prevHistory,
     ]);
+
+    setLastRunSystemPrompt(customPrompt);
+    setLastRunUserMessage(buildUserMessage());
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
@@ -1011,8 +1016,8 @@ const handleRun = async () => {
               content={output}
               outputType={agent.outputType}
               agentName={agent.name}
-              systemPrompt={customPrompt}
-              userMessage={buildUserMessage()}
+              systemPrompt={lastRunSystemPrompt}
+              userMessage={lastRunUserMessage}
             />
             <div className="flex items-center gap-2 mt-3">
   <button

--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Copy, Check, FileText } from 'lucide-react'
+import { Copy, Check, FileText, Download } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -81,52 +81,90 @@ function CopyButton({ text, label, icon: Icon = Copy }) {
   )
 }
 
-function DownloadButton({ text, agentName }) {
-  const handleDownload = () => {
-    const blob = new Blob([text], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${agentName || 'output'}.txt`
-    a.click()
-    setTimeout(() => URL.revokeObjectURL(url), 1000)
-  }
-
-  return (
-    <button
-      onClick={handleDownload}
-      title="Download as .txt"
-      className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors
-        dark:bg-surface-input dark:text-text-secondary dark:hover:text-text-primary dark:border-border
-        bg-gray-100 text-gray-500 hover:text-gray-900 border border-gray-200"
-    >
-      ⬇ Download
-    </button>
-  )
-}
-
-export default function OutputRenderer({ content, outputType, agentName, systemPrompt }) {
+export default function OutputRenderer({ content, outputType, agentName, systemPrompt, userMessage }) {
   if (!content) return null
 
   const shareText = `--- Agent: ${agentName} ---\n\n--- Output ---\n${content}`
+
+  const handleDownloadTxt = () => {
+    const timestamp = new Date().toISOString();
+    const logText = `==================================================
+AGENT RUN LOG: ${agentName || 'Agent'}
+Timestamp: ${timestamp}
+==================================================
+
+--- System Prompt ---
+${systemPrompt || 'N/A'}
+
+--- User Inputs ---
+${userMessage || 'N/A'}
+
+--- Output ---
+${content || ''}
+`;
+    const blob = new Blob([logText], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${agentName ? agentName.replace(/\s+/g, '_').toLowerCase() : 'agent'}_run_log.txt`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const handleDownloadJson = () => {
+    const timestamp = new Date().toISOString();
+    const logObj = {
+      agentName: agentName || 'Agent',
+      timestamp: timestamp,
+      systemPrompt: systemPrompt || '',
+      inputs: userMessage || '',
+      output: content || ''
+    };
+    const blob = new Blob([JSON.stringify(logObj, null, 2)], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${agentName ? agentName.replace(/\s+/g, '_').toLowerCase() : 'agent'}_run_log.json`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
 
   return (
     <div className="animate-fade-in">
       {/* Toolbar */}
       <div className="flex items-center justify-between mb-3">
-        <span className="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
+        <span class="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
           Output
         </span>
         <div className="flex items-center gap-2">
           {/* VoiceOutput — reads the response aloud */}
           <VoiceOutput
-          text={typeof content === 'string' ? content : JSON.stringify(content)}
+            text={typeof content === 'string' ? content : JSON.stringify(content)}
           />
 
           <CopyButton text={content} label="Copy output" />
           <CopyButton text={stripMarkdown(content)} label="Copy as Plain Text" icon={FileText} />
           <CopyButton text={shareText} label="Share" />
-          <DownloadButton text={content} agentName={agentName} />
+          <button
+            onClick={handleDownloadTxt}
+            title="Download full run log as Text"
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors
+              dark:bg-surface-input dark:text-text-secondary dark:hover:text-text-primary dark:border-border
+              bg-gray-100 text-gray-500 hover:text-gray-900 border border-gray-200"
+          >
+            <Download size={12} />
+            Export TXT
+          </button>
+          <button
+            onClick={handleDownloadJson}
+            title="Download full run log as JSON"
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors
+              dark:bg-surface-input dark:text-text-secondary dark:hover:text-text-primary dark:border-border
+              bg-gray-100 text-gray-500 hover:text-gray-900 border border-gray-200"
+          >
+            <Download size={12} />
+            Export JSON
+          </button>
         </div>
       </div>
 

--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -84,7 +84,12 @@ function CopyButton({ text, label, icon: Icon = Copy }) {
 export default function OutputRenderer({ content, outputType, agentName, systemPrompt, userMessage }) {
   if (!content) return null
 
-  const shareText = `--- Agent: ${agentName} ---\n\n--- Output ---\n${content}`
+  // Normalize content to string for safe text operations (JSON outputs might be objects)
+  const stringContent = typeof content === 'object' && content !== null
+    ? JSON.stringify(content, null, 2)
+    : String(content || '');
+
+  const shareText = `--- Agent: ${agentName} ---\n\n--- Output ---\n${stringContent}`
 
   const handleDownloadTxt = () => {
     const timestamp = new Date().toISOString();
@@ -100,7 +105,7 @@ ${systemPrompt || 'N/A'}
 ${userMessage || 'N/A'}
 
 --- Output ---
-${content || ''}
+${stringContent}
 `;
     const blob = new Blob([logText], { type: 'text/plain;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -133,17 +138,17 @@ ${content || ''}
     <div className="animate-fade-in">
       {/* Toolbar */}
       <div className="flex items-center justify-between mb-3">
-        <span class="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
+        <span className="text-xs font-semibold uppercase tracking-wider dark:text-text-muted text-gray-400">
           Output
         </span>
         <div className="flex items-center gap-2">
           {/* VoiceOutput — reads the response aloud */}
           <VoiceOutput
-            text={typeof content === 'string' ? content : JSON.stringify(content)}
+            text={stringContent}
           />
 
-          <CopyButton text={content} label="Copy output" />
-          <CopyButton text={stripMarkdown(content)} label="Copy as Plain Text" icon={FileText} />
+          <CopyButton text={stringContent} label="Copy output" />
+          <CopyButton text={stripMarkdown(stringContent)} label="Copy as Plain Text" icon={FileText} />
           <CopyButton text={shareText} label="Share" />
           <button
             onClick={handleDownloadTxt}


### PR DESCRIPTION
 This PR adds the export capabilities to download complete agent run logs (System Prompt, User Inputs, and Outputs) in both TXT and JSON formats to resolve issue #771.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added export options for generated output in **TXT** and **JSON** formats.
  * **TXT export** now includes a complete run log (agent, timestamp, system prompt, user inputs, and output).
  * **JSON export** now includes structured run details (agent name, timestamp, system prompt, user message, and generated content).
* **Improvements / Bug Fixes**
  * Copy/share actions now use a cleaned, consistent text representation of the generated output to ensure exports and copied content match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->