### PR TITLE
fix: persist openrouter api key in globalKeys

### DIFF
--- a/src/lib/globalKeys.js
+++ b/src/lib/globalKeys.js
@@ -5,6 +5,7 @@
  *   iloveagents_openai_key
  *   iloveagents_anthropic_key
  *   iloveagents_gemini_key
+ *   iloveagents_openrouter_key
  *   iloveagents_default_provider
  */
 
@@ -12,18 +13,20 @@ const KEYS = {
   openai:          'iloveagents_openai_key',
   anthropic:       'iloveagents_anthropic_key',
   gemini:          'iloveagents_gemini_key',
+  openrouter:      'iloveagents_openrouter_key',
   defaultProvider: 'iloveagents_default_provider',
 }
 
 /**
  * Read all globally saved keys from localStorage.
- * @returns {{ openai: string, anthropic: string, gemini: string, defaultProvider: string }}
+ * @returns {{ openai: string, anthropic: string, gemini: string, openrouter: string, defaultProvider: string }}
  */
 export function getGlobalKeys() {
   return {
     openai:          localStorage.getItem(KEYS.openai)          || '',
     anthropic:       localStorage.getItem(KEYS.anthropic)       || '',
     gemini:          localStorage.getItem(KEYS.gemini)          || '',
+    openrouter:      localStorage.getItem(KEYS.openrouter)      || '',
     defaultProvider: localStorage.getItem(KEYS.defaultProvider) || '',
   }
 }
@@ -32,18 +35,19 @@ export function getGlobalKeys() {
  * Save keys to localStorage. Only saves non-empty values —
  * passing an empty string does NOT overwrite an existing saved key.
  * To explicitly clear a key use clearGlobalKey(provider).
- * @param {{ openai?: string, anthropic?: string, gemini?: string, defaultProvider?: string }} keys
+ * @param {{ openai?: string, anthropic?: string, gemini?: string, openrouter?: string, defaultProvider?: string }} keys
  */
-export function saveGlobalKeys({ openai, anthropic, gemini, defaultProvider } = {}) {
+export function saveGlobalKeys({ openai, anthropic, gemini, openrouter, defaultProvider } = {}) {
   if (openai          !== undefined && openai.trim()          !== '') localStorage.setItem(KEYS.openai,          openai.trim())
   if (anthropic       !== undefined && anthropic.trim()       !== '') localStorage.setItem(KEYS.anthropic,       anthropic.trim())
   if (gemini          !== undefined && gemini.trim()          !== '') localStorage.setItem(KEYS.gemini,          gemini.trim())
+  if (openrouter      !== undefined && openrouter.trim()      !== '') localStorage.setItem(KEYS.openrouter,      openrouter.trim())
   if (defaultProvider !== undefined && defaultProvider.trim() !== '') localStorage.setItem(KEYS.defaultProvider, defaultProvider.trim())
 }
 
 /**
  * Remove a single provider's key from localStorage.
- * @param {'openai' | 'anthropic' | 'gemini'} provider
+ * @param {'openai' | 'anthropic' | 'gemini' | 'openrouter'} provider
  */
 export function clearGlobalKey(provider) {
   const storageKey = KEYS[provider]
@@ -51,7 +55,7 @@ export function clearGlobalKey(provider) {
 }
 
 /**
- * Remove all four localStorage entries managed by this module.
+ * Remove all localStorage entries managed by this module.
  */
 export function clearAllGlobalKeys() {
   Object.values(KEYS).forEach((k) => localStorage.removeItem(k))
@@ -66,6 +70,7 @@ export function getAvailableProviders() {
     openai:    'OpenAI',
     anthropic: 'Anthropic',
     gemini:    'Google Gemini',
+    openrouter: 'OpenRouter',
   }
 
   const keys = getGlobalKeys()
@@ -73,3 +78,4 @@ export function getAvailableProviders() {
     .filter(([id]) => keys[id] && keys[id].trim() !== '')
     .map(([id, label]) => ({ id, label }))
 }
+

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -56,7 +56,7 @@ export default function HomePage() {
   const [showBanner, setShowBanner] = useState(() => {
     if (localStorage.getItem('iloveagents_banner_dismissed') === 'true') return false
     const keys = getGlobalKeys()
-    return !keys.openai && !keys.anthropic && !keys.gemini
+    return !keys.openai && !keys.anthropic && !keys.gemini && !keys.openrouter
   })
 
   const dismissBanner = () => {


### PR DESCRIPTION
### What changes were made and why
- Added OpenRouter key persistence support to globalKeys.js.
- Updated getGlobalKeys() and saveGlobalKeys() to store and load openrouter keys from localStorage.
- Added OpenRouter to getAvailableProviders() so it appears under Default Provider options in Settings.
- Updated first-time user banner check in HomePage.jsx to include openrouter.

Closes #829