### PR TITLE
refactor: clear API key from sessionStorage when input is empty

### DIFF
--- a/src/lib/useApiKey.js
+++ b/src/lib/useApiKey.js
@@ -62,7 +62,7 @@ export function useApiKey() {
   const updateApiKey = useCallback(
     (key) => {
       setApiKey(key)
-      if (saveForSession && key) {
+      if (saveForSession) {
         setSafeApiKey(provider, key)
       }
     },


### PR DESCRIPTION
### What changes were made and why
- Removed the truthiness check on key inside updateApiKey in src/lib/useApiKey.js.
- Now, when the user clears the API key input, setSafeApiKey(provider, '') properly deletes the entry from sessionStorage so the deleted key does not reappear.

Closes #831