### PR TITLE
fix: update analytics state after seedFromHistory

### DIFF
--- a/src/lib/useAnalytics.js
+++ b/src/lib/useAnalytics.js
@@ -55,6 +55,7 @@ function seedFromHistory() {
     if (seeded.length > 0) {
       const merged = [...seeded, ...existing].slice(0, MAX_EVENTS)
       saveEvents(merged)
+      window.dispatchEvent(new Event('ila_analytics_update'))
     }
   } catch {}
 
@@ -270,8 +271,11 @@ function toDateKey(d) {
 // ── React hook ──────────────────────────────────────────────────────────────
 
 export function useAnalytics(timeRange = 'all') {
-  // Seed on first ever mount
-  useEffect(() => { seedFromHistory() }, [])
+  // Seed on first ever mount and sync state
+  useEffect(() => {
+    seedFromHistory()
+    setEvents(loadEvents())
+  }, [])
 
   const [events, setEvents] = useState(loadEvents)
 


### PR DESCRIPTION
### What changes were made and why
- Updated seedFromHistory() in src/lib/useAnalytics.js to dispatch window.dispatchEvent(new Event('ila_analytics_update')) after saving seeded history events to localStorage.
- Updated useAnalytics() hook to sync state with setEvents(loadEvents()) immediately upon mounting and seeding.
- Fixes initial visit rendering an empty dashboard when existing run history is present.

Closes #827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics views now refresh immediately after historical data is imported.
  * Initial analytics displays now include seeded historical events without requiring a later update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->