### PR TITLE
fix: store global API keys in sessionStorage with expiry, not localStorage

### DIFF
--- a/src/lib/globalKeys.js
+++ b/src/lib/globalKeys.js
@@ -7,6 +7,11 @@
  * indefinitely in plaintext and defeat that policy. The non-sensitive
  * default-provider preference stays in localStorage.
  *
+ * Note: sessionStorage is still readable by injected scripts, so it does not by
+ * itself protect keys from XSS — the 8-hour expiry only bounds the exposure
+ * window. Stronger protection would require a server-side session or an
+ * HttpOnly cookie for the secret material.
+ *
  * Session key names:
  *   iloveagents_openai_key
  *   iloveagents_anthropic_key
@@ -30,8 +35,16 @@ const EXPIRY_MS = 8 * 60 * 60 * 1000 // 8 hours, matching useApiKey.js
  * legacy plaintext key an older version may have left in localStorage.
  */
 function readSecret(storageKey) {
-  // Clean up legacy localStorage leak from previous versions.
-  if (localStorage.getItem(storageKey) !== null) localStorage.removeItem(storageKey)
+  // Migrate a legacy plaintext key an older version left in localStorage:
+  // move its value into sessionStorage (with a fresh expiry) so the user does
+  // not lose it, then remove the insecure localStorage copy.
+  const legacy = localStorage.getItem(storageKey)
+  if (legacy !== null) {
+    localStorage.removeItem(storageKey)
+    if (legacy !== '' && sessionStorage.getItem(storageKey) === null) {
+      writeSecret(storageKey, legacy)
+    }
+  }
 
   const raw = sessionStorage.getItem(storageKey)
   if (!raw) return ''

--- a/src/lib/globalKeys.js
+++ b/src/lib/globalKeys.js
@@ -1,64 +1,110 @@
 /**
- * globalKeys.js — manages persistent API key storage in localStorage.
+ * globalKeys.js — manages saved API keys for the current browser session.
  *
- * Keys are stored under these exact names:
+ * API keys are secrets, so they live in sessionStorage (cleared when the tab
+ * closes) wrapped with an 8-hour expiry — matching the policy already used in
+ * useApiKey.js. They are NOT written to localStorage, which would persist them
+ * indefinitely in plaintext and defeat that policy. The non-sensitive
+ * default-provider preference stays in localStorage.
+ *
+ * Session key names:
  *   iloveagents_openai_key
  *   iloveagents_anthropic_key
  *   iloveagents_gemini_key
  *   iloveagents_openrouter_key
+ * Preference name (localStorage):
  *   iloveagents_default_provider
  */
 
 const KEYS = {
-  openai:          'iloveagents_openai_key',
-  anthropic:       'iloveagents_anthropic_key',
-  gemini:          'iloveagents_gemini_key',
-  openrouter:      'iloveagents_openrouter_key',
-  defaultProvider: 'iloveagents_default_provider',
+  openai:     'iloveagents_openai_key',
+  anthropic:  'iloveagents_anthropic_key',
+  gemini:     'iloveagents_gemini_key',
+  openrouter: 'iloveagents_openrouter_key',
 }
+const DEFAULT_PROVIDER_KEY = 'iloveagents_default_provider'
+const EXPIRY_MS = 8 * 60 * 60 * 1000 // 8 hours, matching useApiKey.js
 
 /**
- * Read all globally saved keys from localStorage.
- * @returns {{ openai: string, anthropic: string, gemini: string, openrouter: string, defaultProvider: string }}
+ * Read a secret from sessionStorage, honoring its expiry. Also removes any
+ * legacy plaintext key an older version may have left in localStorage.
  */
-export function getGlobalKeys() {
-  return {
-    openai:          localStorage.getItem(KEYS.openai)          || '',
-    anthropic:       localStorage.getItem(KEYS.anthropic)       || '',
-    gemini:          localStorage.getItem(KEYS.gemini)          || '',
-    openrouter:      localStorage.getItem(KEYS.openrouter)      || '',
-    defaultProvider: localStorage.getItem(KEYS.defaultProvider) || '',
+function readSecret(storageKey) {
+  // Clean up legacy localStorage leak from previous versions.
+  if (localStorage.getItem(storageKey) !== null) localStorage.removeItem(storageKey)
+
+  const raw = sessionStorage.getItem(storageKey)
+  if (!raw) return ''
+  try {
+    const { key, expiresAt } = JSON.parse(raw)
+    if (Date.now() > expiresAt) {
+      sessionStorage.removeItem(storageKey)
+      return ''
+    }
+    return key || ''
+  } catch {
+    return raw // tolerate a legacy plaintext session value
   }
 }
 
 /**
- * Save keys to localStorage. Only saves non-empty values —
- * passing an empty string does NOT overwrite an existing saved key.
- * To explicitly clear a key use clearGlobalKey(provider).
- * @param {{ openai?: string, anthropic?: string, gemini?: string, openrouter?: string, defaultProvider?: string }} keys
+ * Store a secret in sessionStorage with a fresh 8-hour expiry.
  */
-export function saveGlobalKeys({ openai, anthropic, gemini, openrouter, defaultProvider } = {}) {
-  if (openai          !== undefined && openai.trim()          !== '') localStorage.setItem(KEYS.openai,          openai.trim())
-  if (anthropic       !== undefined && anthropic.trim()       !== '') localStorage.setItem(KEYS.anthropic,       anthropic.trim())
-  if (gemini          !== undefined && gemini.trim()          !== '') localStorage.setItem(KEYS.gemini,          gemini.trim())
-  if (openrouter      !== undefined && openrouter.trim()      !== '') localStorage.setItem(KEYS.openrouter,      openrouter.trim())
-  if (defaultProvider !== undefined && defaultProvider.trim() !== '') localStorage.setItem(KEYS.defaultProvider, defaultProvider.trim())
+function writeSecret(storageKey, value) {
+  sessionStorage.setItem(storageKey, JSON.stringify({
+    key: value,
+    expiresAt: Date.now() + EXPIRY_MS,
+  }))
 }
 
 /**
- * Remove a single provider's key from localStorage.
+ * Read all globally saved keys.
+ * @returns {{ openai: string, anthropic: string, gemini: string, openrouter: string, defaultProvider: string }}
+ */
+export function getGlobalKeys() {
+  return {
+    openai:          readSecret(KEYS.openai),
+    anthropic:       readSecret(KEYS.anthropic),
+    gemini:          readSecret(KEYS.gemini),
+    openrouter:      readSecret(KEYS.openrouter),
+    defaultProvider: localStorage.getItem(DEFAULT_PROVIDER_KEY) || '',
+  }
+}
+
+/**
+ * Save keys. Only saves non-empty values — passing an empty string does NOT
+ * overwrite an existing saved key. To explicitly clear a key use clearGlobalKey(provider).
+ * @param {{ openai?: string, anthropic?: string, gemini?: string, openrouter?: string, defaultProvider?: string }} keys
+ */
+export function saveGlobalKeys({ openai, anthropic, gemini, openrouter, defaultProvider } = {}) {
+  if (openai          !== undefined && openai.trim()          !== '') writeSecret(KEYS.openai,          openai.trim())
+  if (anthropic       !== undefined && anthropic.trim()       !== '') writeSecret(KEYS.anthropic,       anthropic.trim())
+  if (gemini          !== undefined && gemini.trim()          !== '') writeSecret(KEYS.gemini,          gemini.trim())
+  if (openrouter      !== undefined && openrouter.trim()      !== '') writeSecret(KEYS.openrouter,      openrouter.trim())
+  if (defaultProvider !== undefined && defaultProvider.trim() !== '') localStorage.setItem(DEFAULT_PROVIDER_KEY, defaultProvider.trim())
+}
+
+/**
+ * Remove a single provider's saved key.
  * @param {'openai' | 'anthropic' | 'gemini' | 'openrouter'} provider
  */
 export function clearGlobalKey(provider) {
   const storageKey = KEYS[provider]
-  if (storageKey) localStorage.removeItem(storageKey)
+  if (storageKey) {
+    sessionStorage.removeItem(storageKey)
+    localStorage.removeItem(storageKey) // clear any legacy leak too
+  }
 }
 
 /**
- * Remove all localStorage entries managed by this module.
+ * Remove all key entries managed by this module (both current and legacy).
  */
 export function clearAllGlobalKeys() {
-  Object.values(KEYS).forEach((k) => localStorage.removeItem(k))
+  Object.values(KEYS).forEach((k) => {
+    sessionStorage.removeItem(k)
+    localStorage.removeItem(k)
+  })
+  localStorage.removeItem(DEFAULT_PROVIDER_KEY)
 }
 
 /**
@@ -78,4 +124,3 @@ export function getAvailableProviders() {
     .filter(([id]) => keys[id] && keys[id].trim() !== '')
     .map(([id, label]) => ({ id, label }))
 }
-


### PR DESCRIPTION
## Problem
`src/lib/globalKeys.js` persisted provider API keys in **plaintext `localStorage` with no expiry**. This contradicts the app's own security policy — `src/lib/useApiKey.js` deliberately uses `sessionStorage` and wraps keys with an 8-hour expiry, commenting *"to prevent indefinite persistence even if storage backend is changed to localStorage."* `globalKeys.js` bypassed both.

## Fix
- Move the four secret keys (openai / anthropic / gemini / openrouter) to **`sessionStorage`**, wrapped with the same `{ key, expiresAt }` **8h expiry** as `useApiKey.js`.
- Keep the non-sensitive `default_provider` **preference** in `localStorage`.
- Proactively **remove any key a previous version leaked** to `localStorage` on read/clear (migration cleanup).
- **Public API unchanged** (`getGlobalKeys`, `saveGlobalKeys`, `clearGlobalKey`, `clearAllGlobalKeys`, `getAvailableProviders`) — the 3 callers (`ApiKeyBar`, `HomePage`, `SettingsPage`) work as-is.

## Verification
- `node --check` passes.
- Confirmed no other file reads the `iloveagents_*_key` storage names directly, so the change is self-contained.

Fixes #845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * API keys are now stored only for the current browser session and automatically expire after 8 hours.
  * Legacy stored keys are removed when detected.
  * Provider preferences continue to be retained between sessions.
  * Improved handling of invalid or older stored key formats.
  * Clearing individual or all API keys now removes current and legacy stored values appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->