### PR TITLE
feat: add search and filtering to WorkflowLibrary

### DIFF
--- a/src/pages/WorkflowLibrary.jsx
+++ b/src/pages/WorkflowLibrary.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Plus,
@@ -127,6 +127,7 @@ function WorkflowCard({ workflow, onRun, onView, onFork }) {
 export default function WorkflowLibrary() {
   const navigate = useNavigate()
   useDocumentTitle('Workflow Library')
+  const { agents } = useAgents()
   const [workflows, setWorkflows] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -160,11 +161,20 @@ export default function WorkflowLibrary() {
     return () => supabase.removeChannel(channel)
   }, [])
 
-  const filtered = searchQuery.trim()
-    ? workflows.filter((w) =>
-        w.title.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : workflows
+  const filtered = useMemo(() => {
+      const query = searchQuery.trim().toLowerCase()
+      if (!query) return workflows
+
+      return workflows.filter((w) => {
+        const titleMatch = w.title?.toLowerCase().includes(query)
+        const descriptionMatch = w.description?.toLowerCase().includes(query)
+        const categoryMatch = (w.agents ?? []).some((agentId) => {
+          const agent = agents.find((a) => a.id === agentId)
+          return agent?.category?.toLowerCase().includes(query)
+        })
+        return titleMatch || descriptionMatch || categoryMatch
+      })
+    }, [workflows, searchQuery, agents])
 
   const handleRun = (workflow) => {
     navigate(`/workflows/${workflow.id}/run`, { state: { workflow } })


### PR DESCRIPTION
## What does this PR do?
Extends the existing search input on the Workflow Library page to match on title, description, and agent category — previously it only matched title. Category matching resolves each workflow's agent IDs to their category via `useAgents()`, so users can find workflows by the kind of agents they contain (e.g. searching "writing" surfaces workflows using writing-category agents).

Wraps the filter in `useMemo` to avoid recomputing on every render.

Fixes #430

## Type of change
- [x] UI improvement

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — logic-only change to existing search UI (no visual changes to the input itself)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workflow search to include titles, descriptions, and associated agent categories.
  * Search results now update more efficiently for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->