### PR TITLE
feat: add raw output download button to OutputRenderer

### DIFF
--- a/src/components/OutputRenderer.jsx
+++ b/src/components/OutputRenderer.jsx
@@ -134,6 +134,20 @@ ${stringContent}
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
+  // Downloads just the raw output (no system prompt / inputs), as .md if
+  // the output is markdown, otherwise .txt — matches the "Download Output"
+  // request in issue #429.
+  const handleDownloadOutput = () => {
+    const extension = outputType === 'markdown' ? 'md' : 'txt';
+    const blob = new Blob([stringContent], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${agentName ? agentName.replace(/\s+/g, '_').toLowerCase() : 'agent'}_output.${extension}`;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
   return (
     <div className="animate-fade-in">
       {/* Toolbar */}
@@ -150,6 +164,16 @@ ${stringContent}
           <CopyButton text={stringContent} label="Copy output" />
           <CopyButton text={stripMarkdown(stringContent)} label="Copy as Plain Text" icon={FileText} />
           <CopyButton text={shareText} label="Share" />
+          <button
+            onClick={handleDownloadOutput}
+            title="Download raw output only"
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors
+              dark:bg-surface-input dark:text-text-secondary dark:hover:text-text-primary dark:border-border
+              bg-gray-100 text-gray-500 hover:text-gray-900 border border-gray-200"
+          >
+            <Download size={12} />
+            Export Output
+          </button>
           <button
             onClick={handleDownloadTxt}
             title="Download full run log as Text"


### PR DESCRIPTION
## What does this PR do?
`OutputRenderer` already had "Export TXT" / "Export JSON" buttons, but both download a full run log (system prompt + inputs + output), not the raw output on its own as requested in issue #429.

Adds a `handleDownloadOutput` function and "Export Output" button that downloads just the rendered output content via a client-side Blob, as `.md` when the output is markdown or `.txt` otherwise — matching the original request. Filename is derived from the agent name, consistent with the existing export buttons.

Fixes #429

## Type of change
- [x] UI improvement

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — new toolbar button uses the same style/icon pattern as the existing Export TXT/JSON buttons, no new visual pattern introduced.