### PR TITLE
feat: surface token usage and cost on the analytics dashboard

### DIFF
--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -6,6 +6,7 @@ import {
   Calendar, Clock, Target, Download, Filter,
 } from 'lucide-react'
 import { useAnalytics } from '../lib/useAnalytics'
+import { useSessionSpend } from '../lib/useSessionSpend'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
 
 // ── Provider colors ─────────────────────────────────────────────────────────
@@ -67,6 +68,11 @@ export default function AnalyticsPage() {
   const navigate = useNavigate()
   const [timeRange, setTimeRange] = useState('all')
   const { stats, clearAnalytics } = useAnalytics(timeRange)
+  const { runs: spendRuns, totalSpend } = useSessionSpend()
+  const totalTokens = useMemo(
+    () => spendRuns.reduce((sum, r) => sum + (r.inputTokens || 0) + (r.outputTokens || 0), 0),
+    [spendRuns]
+  )
 
   // ── Empty state ───────────────────────────────────────────────────────────
   if (stats.totalRuns === 0 && timeRange === 'all') {
@@ -229,8 +235,15 @@ export default function AnalyticsPage() {
         <RecentTimeline runs={stats.recentRuns} navigate={navigate} />
       </SectionCard>
 
-      {/* ── Export Bar ── */}
-      <ExportBar stats={stats} />
+      {/* ── Token Usage & Cost (current session) ── */}
+        {spendRuns.length > 0 && (
+          <SectionCard title="Token Usage & Cost (This Session)" icon={<Zap size={16} />} delay={760}>
+            <TokenUsageSection runs={spendRuns} totalTokens={totalTokens} totalSpend={totalSpend} />
+          </SectionCard>
+        )}
+
+        {/* ── Export Bar ── */}
+        <ExportBar stats={stats} />
     </div>
   )
 }
@@ -694,6 +707,66 @@ function RecentTimeline({ runs, navigate }) {
           </div>
         )
       })}
+    </div>
+  )
+}
+
+// ── Token Usage & Cost Section ──────────────────────────────────────────────
+
+function formatSpend(cost) {
+  if (cost == null || isNaN(cost)) return '—'
+  if (cost < 0.01) return `$${cost.toFixed(4)}`
+  return `$${cost.toFixed(2)}`
+}
+
+function TokenUsageSection({ runs, totalTokens, totalSpend }) {
+  const recentRuns = runs.slice(0, 10)
+
+  return (
+    <div>
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <div className="p-3 rounded-lg dark:bg-surface-input bg-gray-50 border dark:border-border border-gray-200">
+          <div className="text-lg font-bold dark:text-text-primary text-gray-900 tabular-nums">
+            {totalTokens.toLocaleString()}
+          </div>
+          <div className="text-[10px] dark:text-text-muted text-gray-400 font-medium">
+            Total tokens (session)
+          </div>
+        </div>
+        <div className="p-3 rounded-lg dark:bg-surface-input bg-gray-50 border dark:border-border border-gray-200">
+          <div className="text-lg font-bold dark:text-text-primary text-gray-900 tabular-nums">
+            {formatSpend(totalSpend)}
+          </div>
+          <div className="text-[10px] dark:text-text-muted text-gray-400 font-medium">
+            Estimated cost (session)
+          </div>
+        </div>
+      </div>
+
+      <div className="text-[11px] font-medium dark:text-text-muted text-gray-400 mb-2">
+        Recent runs
+      </div>
+      <div className="space-y-1.5 max-h-64 overflow-y-auto pr-1 custom-scrollbar">
+        {recentRuns.map((run, i) => (
+          <div
+            key={`${run.timestamp}-${i}`}
+            className="flex items-center justify-between px-3 py-2 rounded-lg
+              dark:bg-surface-input bg-gray-50 border dark:border-border border-gray-200"
+          >
+            <div className="min-w-0">
+              <div className="text-xs font-medium dark:text-text-primary text-gray-800 truncate max-w-[160px]">
+                {run.model || 'Unknown model'}
+              </div>
+              <div className="text-[10px] dark:text-text-muted text-gray-400">
+                {(run.inputTokens || 0).toLocaleString()} in · {(run.outputTokens || 0).toLocaleString()} out
+              </div>
+            </div>
+            <div className="text-xs font-semibold dark:text-text-primary text-gray-900 tabular-nums shrink-0">
+              {formatSpend(run.totalCost)}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -101,6 +101,14 @@ export default function AnalyticsPage() {
             <ArrowRight size={14} />
           </button>
         </div>
+
+        {/* Session spend can exist even with no recorded analytics events
+            (e.g. analytics was cleared but session spend wasn't) */}
+        {spendRuns.length > 0 && (
+          <SectionCard title="Token Usage & Cost (This Session)" icon={<Zap size={16} />} delay={200}>
+            <TokenUsageSection runs={spendRuns} totalTokens={totalTokens} totalSpend={totalSpend} />
+          </SectionCard>
+        )}
       </div>
     )
   }
@@ -129,6 +137,14 @@ export default function AnalyticsPage() {
             Show All Time
           </button>
         </div>
+
+        {/* Session spend is not filtered by time range, so it can still
+            be shown here even when the selected range has no runs */}
+        {spendRuns.length > 0 && (
+          <SectionCard title="Token Usage & Cost (This Session)" icon={<Zap size={16} />} delay={200}>
+            <TokenUsageSection runs={spendRuns} totalTokens={totalTokens} totalSpend={totalSpend} />
+          </SectionCard>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## What does this PR do?
Issue #423 asks for token/cost visibility into agent execution. `AgentRunner` already tracks per-run tokens and estimated cost via `useSessionSpend`, but that data was never surfaced anywhere in the UI.

Adds a "Token Usage & Cost (This Session)" section to `AnalyticsPage` showing total tokens consumed, total estimated spend, and a scrollable list of recent runs with per-run token/cost breakdown by model.

**Scope note:** this covers session-level tracking (tokens, cost per run, per model) as a first, reviewable slice of the larger dashboard requested in #423. Model-wise trend charts, daily/weekly/monthly aggregation, and consumption alerts are left for follow-up PRs to keep this change focused and easy to review.
Closes #423

## Type of change
- [x] UI improvement

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — new section follows the existing `SectionCard` pattern already used throughout this page (Activity, Top Agents, Providers, etc.), so it's visually consistent with the rest of the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token usage and estimated cost insights to the Analytics page.
  * Displays aggregate session metrics across populated, empty, and filtered views.
  * Lists up to ten recent runs with model, token usage, and estimated cost details.
  * Added formatted cost information while preserving export controls in the Analytics experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->