### PR TITLE
fix: remove duplicate gemini-2.5-flash entry in model dropdown (#849)

### DIFF
--- a/src/lib/resolveAgentModel.js
+++ b/src/lib/resolveAgentModel.js
@@ -15,7 +15,6 @@ export const MODELS = {
     { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
     { value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' },
     { value: 'gemini-2.0-flash-exp', label: 'Gemini 2.0 Flash (Exp)' },
-    { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
   ],
   openrouter: [
     { value: 'openai/gpt-4o-mini', label: 'GPT-4o Mini' },


### PR DESCRIPTION
### What & why
`src/lib/resolveAgentModel.js` — `gemini-2.5-flash` appears **twice** in `MODELS.gemini` (indices 0 and 3). The model `<select>` therefore renders two identical options with the same `value` (a redundant option, plus a React duplicate-key warning when keyed by value).

### Fix
Remove the second copy. Index 0 stays — which `MODEL_MAP.gemini` already references — so the default is unaffected.

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a duplicate Gemini model entry from the available model list.
  * Gemini models now appear without duplicate options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->