### PR TITLE
fix: use a valid Anthropic model id for Analyse Models & Custom Suite defaults

### DIFF
--- a/src/lib/customSuiteGenerator.js
+++ b/src/lib/customSuiteGenerator.js
@@ -4,7 +4,7 @@ import { suites } from "../suites/suitesData";
 
 const MODEL_DEFAULTS = {
   gemini: "gemini-2.5-flash",
-  anthropic: "claude-3.5-haiku",
+  anthropic: "claude-3-5-haiku-20241022",
   openai: "gpt-4o-mini",
 };
 

--- a/src/lib/modelAnalyser.js
+++ b/src/lib/modelAnalyser.js
@@ -56,7 +56,7 @@ Be specific and practical. Consider context window, speed, cost and output quali
 
   const MODEL_DEFAULTS = {
     gemini: "gemini-2.5-flash",
-    anthropic: "claude-3.5-Haiku",
+    anthropic: "claude-3-5-haiku-20241022",
     openai: "gpt-4o-mini",
 
   };


### PR DESCRIPTION
### Problem
`src/lib/modelAnalyser.js` and `src/lib/customSuiteGenerator.js` default the Anthropic provider to `"claude-3.5-Haiku"` / `"claude-3.5-haiku"`. Those dotted ids are **not valid Anthropic model ids** — the Messages API requires the hyphenated form (`claude-3-5-haiku-20241022`), which the rest of the app already uses (`resolveAgentModel.js:11`, `modelPricing.js:32`). So **Analyse Models** and **Custom Suite Generator** fail with an invalid-model error for every user on the Anthropic provider.

### Fix
Replace both defaults with `claude-3-5-haiku-20241022` — the exact id used elsewhere, so all Anthropic defaults are consistent.

### Note (out of scope — flagging for a follow-up)
`claude-3-5-haiku-20241022` (Claude Haiku 3.5) reached end-of-life on **2026-02-19**. The whole repo currently pins it, so bumping it (e.g. to `claude-haiku-4-5`) is a separate repo-wide change best done in its own PR. This PR keeps scope tight to the malformed-id bug and stays consistent with the existing code.

Closes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Anthropic model configuration to use the current model identifier.
  * Improved compatibility and reliability for AI-powered suite generation and model analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->