### PR TITLE
fix: notify when no analytics data is available to clear

### DIFF
--- a/src/lib/useAnalytics.js
+++ b/src/lib/useAnalytics.js
@@ -294,9 +294,13 @@ export function useAnalytics(timeRange = 'all') {
   const stats = useMemo(() => computeStats(events, timeRange), [events, timeRange])
 
   const clearAnalytics = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY)
-    setEvents([])
-  }, [])
+  if (!events.length) {
+  alert("No analytics data to clear.")
+  return
+}
+  localStorage.removeItem(STORAGE_KEY)
+  setEvents([])
+}, [events])
 
   return { events, stats, clearAnalytics }
 }


### PR DESCRIPTION
## What does this PR do?

Adds feedback when the user clicks the **Clear Data** button while there is no analytics data available.

Previously, clicking the button provided no indication of whether the action was executed. This change displays a notification informing the user that there is no analytics data to clear, improving the user experience.

Closes #843.

## Type of change

- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics clearing behavior when no events are available.
  * Added a clear notification when there are no analytics events to remove.
  * Ensured existing analytics are removed and the displayed state updates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->