### PR TITLE
docs: add Feature Comparison table (#854)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 ## Table of Contents
 
 - [Repository Highlights](#repository-highlights)
+- [Feature Comparison](#feature-comparison)
 - [What is iloveAgents?](#what-is-iloveagents)
 - [Why iloveAgents?](#why-iloveagents)
 - [Available Agents](#available-agents)
@@ -57,6 +58,18 @@
 - **Browser-based** — run AI agents directly in your browser
 - **Extensible architecture** — add new agents easily
 - **Contributor-friendly** — active community, easy to get started
+
+---
+
+## Feature Comparison
+
+A quick side-by-side look at the platform's core features:
+
+| Feature | Purpose | Requires API Key | Requires Supabase | Supports Multiple Providers |
+|---|---|:---:|:---:|:---:|
+| Individual Agents | Run a single AI agent | ✅ | ❌ | ✅ |
+| Battle Mode | Compare responses from multiple AI providers | ✅ | ❌ | ✅ |
+| Workflow Builder | Chain multiple AI agents together | ✅ | ✅ | ✅ |
 
 ---
 


### PR DESCRIPTION
Closes #854
## What does this PR do?
Adds a "Feature Comparison" table to the README, right after the "Repository Highlights" section, comparing Individual Agents, Battle Mode, and Workflow Builder by purpose, API key requirement, Supabase requirement, and multi-provider support. Also added the new section to the Table of Contents. Closes #854.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [x] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — documentation-only change (README.md)