### PR TITLE
fix: remove duplicate gemini-2.5-flash key and correct pricing (#846)

### DIFF
--- a/src/lib/modelPricing.js
+++ b/src/lib/modelPricing.js
@@ -41,12 +41,6 @@ export const MODEL_PRICING = {
     outputCostPer1M: 75.00,
     contextWindow: 200000,
   },
-  'gemini-2.5-flash': {
-    provider: 'gemini',
-    inputCostPer1M: 0.075,
-    outputCostPer1M: 0.30,
-    contextWindow: 1000000,
-  },
   'gemini-1.5-pro': {
     provider: 'gemini',
     inputCostPer1M: 1.25,
@@ -61,8 +55,8 @@ export const MODEL_PRICING = {
   },
   'gemini-2.5-flash': {
     provider: 'gemini',
-    inputCostPer1M: 0.15,
-    outputCostPer1M: 0.60,
+    inputCostPer1M: 0.30,
+    outputCostPer1M: 2.50,
     contextWindow: 1000000,
   },
   'openai/gpt-4o-mini': {


### PR DESCRIPTION
Closes #846
## What does this PR do?
Fixes #846 — `src/lib/modelPricing.js` defined the 'gemini-2.5-flash' key twice in the same object literal. JS silently kept only the last definition, making the first entry dead code and hiding a pricing conflict.

- Deleted dead-code duplicate entry (input 0.075/output 0.30) that was silently overwritten
- Updated surviving entry to current official Google pricing: 0.30 input / 2.50 output per 1M tokens (source: ai.google.dev/gemini-api/docs/pricing)
- Previous surviving value (0.15/0.60) was also stale, not just the deleted duplicate
- Left the `google/gemini-2.5-flash` OpenRouter entry untouched — OpenRouter sets its own margin on the base model, so a different rate there is expected and out of scope for this issue

## Type of change
- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [ ] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — pricing constant change, not a UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Gemini 2.5 Flash token pricing to reflect current rates.
  - Input token pricing is now $0.30 per million tokens.
  - Output token pricing is now $2.50 per million tokens.
  - Removed the outdated duplicate pricing entry to ensure cost estimates use the correct rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->