### PR TITLE
fix: use template literal for ApiKeyBar checkbox label className (#848)

### DIFF
--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -201,7 +201,7 @@ export default function ApiKeyBar({
         </div>
 
         {/* Save checkbox */}
-        <label className="flex items-center gap-1.5 select-none ${!apiKey?.trim() ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`">
+        <label className={`flex items-center gap-1.5 select-none ${!apiKey?.trim() ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}>
           <input
             type="checkbox"
             checked={saveForSession}


### PR DESCRIPTION
## What does this PR do?
Closes #848 
`ApiKeyBar.jsx` used template-literal `${}` syntax inside a plain double-quoted `className` string, so the conditional (`opacity-40 cursor-not-allowed` / `cursor-pointer`) was never evaluated and instead rendered as literal garbage text in the DOM class attribute, along with a stray trailing backtick. Changed the attribute to a proper JSX expression container with a template literal: `className={\`...\`}`, so the "Save for session" checkbox label now correctly dims and shows `cursor-not-allowed` when no API key is entered.

## Type of change
- [x] Bug fix

## Checklist
- [x] I ran `npm run build` locally and it passed 
- [x] I tested my changes in the browser 
- [x] I did not break any existing agents 
- [x] I did not use `import agents from '../agents/registry'` 
- [x] My PR has a clear description above 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Save for session” label styling so it displays correctly based on whether an API key is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->