### PR TITLE
fix: apply saved default provider in ApiKeyBar

### DIFF
--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -1,5 +1,5 @@
 import { fetchGeminiModels } from '../lib/llmAdapter'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Eye, EyeOff, ShieldCheck } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import CustomSelect from './CustomSelect'
@@ -79,14 +79,26 @@ export default function ApiKeyBar({
     if (savedKey && !apiKey) {
       setApiKey(savedKey)
     }
-    // Also set default provider if none selected and a default exists
-    if (globalKeys.defaultProvider && provider !== globalKeys.defaultProvider) {
-      // Only set if the agent allows any provider
-      if (agentProvider === 'any') {
-        // Don't override the user's current selection — only on initial mount
-      }
-    }
   }, [provider])
+
+  // ── Apply saved default provider once on mount, only if the agent
+  // doesn't require a specific provider. We only want this on initial
+  // mount — not every time `provider` changes — otherwise it would
+  // fight the user's own manual selection.
+  const hasAppliedDefaultProvider = useRef(false)
+  useEffect(() => {
+    if (hasAppliedDefaultProvider.current) return
+    hasAppliedDefaultProvider.current = true
+
+    const globalKeys = getGlobalKeys()
+    if (
+      agentProvider === 'any' &&
+      globalKeys.defaultProvider &&
+      provider !== globalKeys.defaultProvider
+    ) {
+      setProvider(globalKeys.defaultProvider)
+    }
+  }, [])
 
   useEffect(() => {
     if (provider !== 'gemini' || !apiKey?.trim()) {

--- a/src/components/ApiKeyBar.jsx
+++ b/src/components/ApiKeyBar.jsx
@@ -91,9 +91,11 @@ export default function ApiKeyBar({
     hasAppliedDefaultProvider.current = true
 
     const globalKeys = getGlobalKeys()
+    const isValidProvider = PROVIDERS.some((p) => p.value === globalKeys.defaultProvider)
+
     if (
       agentProvider === 'any' &&
-      globalKeys.defaultProvider &&
+      isValidProvider &&
       provider !== globalKeys.defaultProvider
     ) {
       setProvider(globalKeys.defaultProvider)


### PR DESCRIPTION
## Summary

Fixes the issue where the default provider configured in **Settings** was never applied in `ApiKeyBar`.

Although the selected default provider was being persisted through `saveGlobalKeys`, `ApiKeyBar.jsx` never restored and applied it. The existing effect already contained a comment indicating this behavior, but the corresponding logic was missing.

**Closes #884**

## Changes

* Split the initialization logic into two separate effects:

  * **API key auto-fill** – preserves the existing behavior of loading the saved API key whenever the selected provider changes.
  * **Default provider initialization** – runs only once on initial mount and applies the saved default provider when the agent's provider is `"any"`.

* Added a `useRef` guard so the default provider is applied only during the initial render, preventing it from overriding a user's manual provider selection afterward.

## Why

Previously, users could configure a default provider in **Settings**, but `ApiKeyBar` continued using the previously selected provider because the saved default was never restored.

With this change:

* A configured default provider is automatically selected for agents that support `"any"` provider.
* User-initiated provider changes continue to be respected after initialization.
* Existing API key auto-fill behavior remains unchanged.

## Testing

Manually verified using a temporary local test harness for `ApiKeyBar`:

*  A saved default provider is automatically selected on initial load when `agentProvider === "any"`.
*  API keys continue to auto-fill correctly after provider changes.
*  Manually changing the provider is preserved and is not overwritten after the initial initialization.

**Note:** End-to-end testing through the normal agent flow could not be completed because of an unrelated pre-existing runtime error (`viewMode is not defined` in `AgentRunner.jsx`), which is outside the scope of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider selection behavior when the app loads.
  * Global default provider settings are applied only once during initial loading.
  * Changing providers no longer unexpectedly resets the selected provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->