### PR TITLE
fix: make add to collection modal scrollable

### DIFF
--- a/src/components/CollectionPicker.jsx
+++ b/src/components/CollectionPicker.jsx
@@ -32,8 +32,8 @@ export default function CollectionPicker({ agentId, onClose }) {
           <div className="flex items-start gap-3"><div className="rounded-lg bg-accent/10 p-2 text-accent"><FolderPlus size={18} /></div><div><h2 className="text-base font-semibold text-gray-900 dark:text-text-primary">Add to Collection</h2><p className="mt-1 text-sm text-gray-500 dark:text-text-secondary">Choose a collection or create a new one.</p></div></div>
           <button type="button" onClick={onClose} className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-text-primary" aria-label="Close dialog"><X size={18} /></button>
         </div>
-        <div className="space-y-4 p-5">
-          <div className="space-y-2">
+        <div className="flex min-h-0 flex-1 flex-col p-5">
+          <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
             {visibleCollections.length === 0 ? <p className="text-sm text-gray-500 dark:text-text-secondary">No collections yet.</p> : visibleCollections.map((collection) => {
               const alreadyAdded = isAgentInCollection(collection.id, agentId)
               return <button key={collection.id} type="button" onClick={() => handleAdd(collection)} disabled={alreadyAdded} className="flex w-full items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-left text-sm transition hover:border-accent/50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border dark:hover:border-accent/50"><span className="font-medium text-gray-800 dark:text-text-primary">{collection.name}</span><span className="text-xs text-gray-500 dark:text-text-muted">{alreadyAdded ? 'Already added' : `${collection.agentIds.length} agents`}</span></button>

--- a/src/components/CollectionPicker.jsx
+++ b/src/components/CollectionPicker.jsx
@@ -26,8 +26,8 @@ export default function CollectionPicker({ agentId, onClose }) {
   }
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" role="dialog" aria-modal="true">
-      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-border dark:bg-surface-card">
+    <div className="fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto p-4 pt-8 bg-black/50 backdrop-blur-sm" role="dialog" aria-modal="true">
+      <div className="flex max-h-[80vh] w-full max-w-md flex-col rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-border dark:bg-surface-card">
         <div className="flex items-start justify-between gap-4 border-b border-gray-100 p-5 dark:border-border">
           <div className="flex items-start gap-3"><div className="rounded-lg bg-accent/10 p-2 text-accent"><FolderPlus size={18} /></div><div><h2 className="text-base font-semibold text-gray-900 dark:text-text-primary">Add to Collection</h2><p className="mt-1 text-sm text-gray-500 dark:text-text-secondary">Choose a collection or create a new one.</p></div></div>
           <button type="button" onClick={onClose} className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-text-primary" aria-label="Close dialog"><X size={18} /></button>


### PR DESCRIPTION
## What does this PR do?

Fixes the "Add to Collection" modal where the **Create** button could become partially hidden when the modal content exceeded the available viewport height.

This change makes the modal scrollable and constrains its maximum height so users can always access the Create button without it being clipped.

Closes #844.

## Type of change

- [ ] New agent
- [x] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)

Before:
- The Create button was partially hidden at the bottom of the "Add to Collection" modal on smaller viewports.

After:
- The modal is scrollable with a constrained height, ensuring the Create button remains accessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the collection picker dialog layout by positioning it nearer the top of the screen.
  * Added a maximum height and independent scrolling for better usability on smaller screens or with many collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->