### PR TITLE
ci: add workflow to manage stale issues and prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Manage Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity for 30 days. It will be closed if no further activity occurs within the next 7 days. Thank you for your contributions.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity for 30 days. It will be closed if no further activity occurs within the next 7 days. Thank you for your contributions.'
+          close-issue-message: 'This issue has been closed due to inactivity. If you feel this was closed in error, please reopen or create a new issue.'
+          close-pr-message: 'This pull request has been closed due to inactivity. If you feel this was closed in error, please reopen or create a new pull request.'
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,enhancement,work-in-progress'
+          exempt-pr-labels: 'pinned,security,enhancement,work-in-progress'


### PR DESCRIPTION
## What does this PR do?
This PR introduces a GitHub Actions workflow (`stale.yml`) to automatically manage inactive issues and pull requests. It uses the `actions/stale` action to:
- Mark issues and PRs as stale after 30 days of inactivity.
- Automatically close them if no activity occurs for 7 additional days.
- Exempt items with labels like `pinned`, `security`, `enhancement`, and `work-in-progress`.
- Ensure repository maintenance requires less manual effort while keeping the backlog clean.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other *(CI/CD automation)*

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A - CI/CD workflow change only.

fixes #907 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily management of inactive issues and pull requests.
  * Items are marked stale after 30 days and closed seven days later if there is no activity.
  * Pinned, security-related, enhancement, and work-in-progress items are excluded from automated handling.
  * The process can also be started manually when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->