### PR TITLE
ci: add dockerfile linting workflow

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,76 @@
+name: Dockerfile Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Hadolint
+        run: |
+          wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          chmod +x /usr/local/bin/hadolint
+
+      - name: Run Hadolint
+        id: lint
+        run: |
+          echo "Searching for Dockerfiles..."
+          # Find all Dockerfile or *.Dockerfile files, ignoring hidden directories like .git
+          dockerfiles=$(find . -not -path '*/\.*' \( -type f -name "Dockerfile" -o -name "*.Dockerfile" \))
+          
+          if [ -z "$dockerfiles" ]; then
+            echo "No Dockerfiles found in the repository."
+            echo "### Dockerfile Lint Summary 🐳" >> $GITHUB_STEP_SUMMARY
+            echo "0 Dockerfiles checked. No Dockerfiles found." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          
+          count=$(echo "$dockerfiles" | wc -w)
+          echo "Found $count Dockerfiles to lint."
+          
+          echo "### Dockerfile Lint Summary 🐳" >> $GITHUB_STEP_SUMMARY
+          echo "**$count** Dockerfiles checked." >> $GITHUB_STEP_SUMMARY
+          
+          exit_code=0
+          # We use a temporary file to collect all lint errors
+          touch hadolint-report.txt
+          
+          for file in $dockerfiles; do
+            echo "Linting $file ..."
+            # Run hadolint; append output to report; capture exit code
+            if ! hadolint "$file" >> hadolint-report.txt 2>&1; then
+              exit_code=1
+            fi
+          done
+          
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          if [ $exit_code -eq 0 ]; then
+            echo "All Dockerfiles passed successfully! 🎉" >> $GITHUB_STEP_SUMMARY
+            echo "All checks passed."
+          else
+            cat hadolint-report.txt >> $GITHUB_STEP_SUMMARY
+            cat hadolint-report.txt
+          fi
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          
+          exit $exit_code
+
+      - name: Upload lint report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hadolint-report
+          path: hadolint-report.txt
+          retention-days: 7


### PR DESCRIPTION
## What does this PR do?
This PR introduces a GitHub Actions workflow (`dockerfile-lint.yml`) to automatically lint all Dockerfiles in the repository using Hadolint. It ensures container configurations follow best practices and remain secure and maintainable by:
- Recursively searching for all `Dockerfile` and `*.Dockerfile` files.
- Running Hadolint on each discovered file.
- Failing the workflow if any linting errors or inefficiencies are found.
- Providing a clear Job Summary within GitHub Actions indicating how many Dockerfiles were checked and the results.
- Automatically uploading the linting report as an artifact if the workflow fails to assist with debugging.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other *(CI/CD automation)*

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A - CI/CD workflow change only.

fixes #913 