### PR TITLE
ci: add trivy filesystem security scan workflow

### DIFF
--- a/.github/workflows/trivy-fs-scan.yml
+++ b/.github/workflows/trivy-fs-scan.yml
@@ -1,0 +1,59 @@
+name: Trivy Filesystem Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at midnight
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in fs mode (SARIF report)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          scanners: 'vuln,secret,config'
+          exit-code: '0' # Don't fail here to ensure we generate the table format next
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Run Trivy vulnerability scanner (Table output)
+        uses: aquasecurity/trivy-action@0.24.0
+        if: always()
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          output: 'trivy-report.txt'
+          severity: 'HIGH,CRITICAL'
+          scanners: 'vuln,secret,config'
+          exit-code: '1' # Fail the workflow if HIGH or CRITICAL issues are found
+
+      - name: Upload Trivy scan report as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-fs-report
+          path: trivy-report.txt
+          retention-days: 7


### PR DESCRIPTION
## What does this PR do?
This PR introduces a GitHub Actions workflow (`trivy-fs-scan.yml`) that utilizes Trivy to perform comprehensive security scanning of the repository filesystem. It improves our project's security posture by:
- Scanning for vulnerable dependencies, misconfigurations, and exposed secrets.
- Automatically generating and uploading a SARIF report directly to GitHub Security alerts.
- Uploading a human-readable table report as a workflow artifact.
- Failing the workflow strictly on `HIGH` and `CRITICAL` severity findings to prevent major security regressions from being merged.
- Running continuously on Pull Requests, pushes to `main`, and on a weekly scheduled basis.
- Operating securely with the minimum required permissions (`contents: read`, `security-events: write`).

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other *(Security / CI/CD automation)*

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A - Security workflow change only.

fixes #915 