### PR TITLE
ci: add documentation link checker workflow

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,63 @@
+name: Docs Link Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
+
+permissions:
+  contents: read
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check Links with Lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Check all markdown files, retry failures, and ignore common local/example domains
+          args: >-
+            --cache
+            --max-retries 3
+            --exclude "localhost"
+            --exclude "127.0.0.1"
+            --exclude "example.com"
+            --exclude "example.org"
+            --format markdown
+            --output lychee-report.md
+            "**/*.md"
+        # We handle failures manually below to ensure reports are uploaded and summary is added
+        continue-on-error: true
+
+      - name: Add summary to job
+        if: always()
+        run: |
+          echo "### Docs Link Check Summary 🔗" >> $GITHUB_STEP_SUMMARY
+          if [ -s lychee-report.md ]; then
+            cat lychee-report.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "All links are valid! 🎉" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload Link Check Report
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-check-report
+          path: lychee-report.md
+          retention-days: 7
+          
+      - name: Fail workflow if broken links exist
+        if: steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "Broken links were found. Please check the summary or the uploaded artifact."
+          exit 1


### PR DESCRIPTION
## What does this PR do?
This PR introduces a GitHub Actions workflow (`docs-link-check.yml`) that utilizes Lychee to automatically validate all links within our Markdown documentation. It prevents broken links from reaching the default branch and ensures a high-quality developer experience by:
- Recursively scanning all `.md` files for broken internal and external links.
- Retrying transient network failures up to 3 times to prevent flaky CI failures.
- Ignoring configurable example and local URLs (e.g., `localhost`, `example.com`).
- Providing a clear Job Summary containing the number of links checked and failures.
- Automatically uploading a Markdown report artifact if any broken links are detected.
- Triggering on PRs, pushes to the main branch, and on a weekly scheduled basis.

## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [x] Other *(CI/CD automation)*

## Checklist
- [x] I ran `npm run build` locally and it passed ✅
- [x] I tested my changes in the browser ✅
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A - CI/CD workflow change only.

fixes #917 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated link checking for Markdown documentation.
  * Link checks run on code changes, pull requests, manual requests, and weekly schedules.
  * Broken links now generate a report, appear in workflow results, and cause the check to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->