### PR TITLE
feat: add ExecutionCostPanel component to display token-based cost estimations in AgentRunner

### DIFF
--- a/src/components/AgentRunner.jsx
+++ b/src/components/AgentRunner.jsx
@@ -26,6 +26,7 @@ import ErrorCard from "./ErrorCard";
 import CharCounter from "./CharCounter";
 import TokenCounter from "./TokenCounter";
 import CostEstimator from "./CostEstimator";
+import ExecutionCostPanel from "./ExecutionCostPanel";
 import { useSessionSpend } from "../lib/useSessionSpend";
 import VoiceInput from "./VoiceInput";
 import SuggestedChainPills from "./SuggestedChainPills";
@@ -85,6 +86,8 @@ export default function AgentRunner({ agent }) {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const [duration, setDuration] = useState(null);
+  const [inputTokenEstimate, setInputTokenEstimate] = useState(null);
+  const [outputTokenEstimate, setOutputTokenEstimate] = useState(null);
   const [selectedModel, setSelectedModel] = useState(
     MODEL_MAP[provider] || MODEL_MAP.openai,
   );
@@ -137,6 +140,8 @@ export default function AgentRunner({ agent }) {
     setIsStreaming(false);
     setError(null);
     setDuration(null);
+    setInputTokenEstimate(null);
+    setOutputTokenEstimate(null);
     setCustomPrompt(agent.systemPrompt);
     setPlaygroundOpen(false);
     setBatchMode(false);
@@ -277,6 +282,8 @@ const handleRun = async () => {
     setStreamingOutput("");
     setIsStreaming(false);
     setDuration(null);
+    setInputTokenEstimate(null);
+    setOutputTokenEstimate(null);
     setMsgIndex(0);
 
       const newVersion = {
@@ -318,16 +325,19 @@ const handleRun = async () => {
       setIsStreaming(false);
       setDuration(result.duration);
 
-      const inputTokenEstimate = Math.max(
+      const currentInputTokenEstimate = Math.max(
         1,
         Math.round((customPrompt.length + buildUserMessage().length) / 4),
       );
-      const outputTokenEstimate = Math.max(1, Math.round(result.content.length / 4));
+      const currentOutputTokenEstimate = Math.max(1, Math.round(result.content.length / 4));
+
+      setInputTokenEstimate(currentInputTokenEstimate);
+      setOutputTokenEstimate(currentOutputTokenEstimate);
 
       addRun({
         model,
-        inputTokens: inputTokenEstimate,
-        outputTokens: outputTokenEstimate,
+        inputTokens: currentInputTokenEstimate,
+        outputTokens: currentOutputTokenEstimate,
         inputCost: null,
         outputCost: null,
       });
@@ -383,6 +393,8 @@ const handleRun = async () => {
     setIsStreaming(false);
     setError(null);
     setDuration(null);
+    setInputTokenEstimate(null);
+    setOutputTokenEstimate(null);
 
     const defaults = {};
     agent.inputs.forEach((input) => {
@@ -1114,6 +1126,12 @@ const handleRun = async () => {
               agentName={agent.name}
               systemPrompt={lastRunSystemPrompt}
               userMessage={lastRunUserMessage}
+            />
+            <ExecutionCostPanel
+              modelId={selectedModel}
+              provider={agent.provider === "any" ? provider : agent.provider}
+              inputTokens={inputTokenEstimate}
+              outputTokens={outputTokenEstimate}
             />
             <div className="flex items-center gap-2 mt-3">
   <button

--- a/src/components/ExecutionCostPanel.jsx
+++ b/src/components/ExecutionCostPanel.jsx
@@ -1,0 +1,87 @@
+import { getPricing, estimateInputCost, estimateOutputCost } from '../lib/modelPricing'
+import { Coins, Info } from 'lucide-react'
+
+function formatCost(cost) {
+  if (cost == null || isNaN(cost)) return '—'
+  if (cost < 0.0001) return '< $0.0001'
+  return `$${cost.toFixed(4)}`
+}
+
+const providerLabels = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  gemini: "Gemini",
+  openrouter: "OpenRouter",
+  any: "Any",
+};
+
+export default function ExecutionCostPanel({ modelId, provider, inputTokens, outputTokens }) {
+  if (!inputTokens || !outputTokens) return null;
+
+  const pricing = getPricing(modelId)
+  
+  const inputCost = pricing ? estimateInputCost(modelId, inputTokens) : null
+  const outputCost = pricing ? estimateOutputCost(modelId, outputTokens) : null
+  const totalCost = pricing && inputCost !== null && outputCost !== null ? inputCost + outputCost : null
+
+  const totalTokens = inputTokens + outputTokens
+
+  return (
+    <div className="mt-4 rounded-lg border dark:bg-surface-card dark:border-border bg-white border-gray-200 p-4 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-1.5">
+          <Coins size={16} className="text-accent" />
+          <span className="text-sm font-semibold dark:text-text-primary text-gray-900">
+            Execution Cost Estimate
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-accent/10 text-accent border border-accent/20">
+            {providerLabels[provider] || provider}
+          </span>
+          <span className="text-[10px] font-medium px-2 py-0.5 rounded-full dark:bg-surface-input dark:text-text-secondary bg-gray-100 text-gray-600 border border-gray-200">
+            {modelId}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Tokens Breakdown */}
+        <div className="col-span-1 md:col-span-2 space-y-2">
+          <div className="flex justify-between text-xs">
+            <span className="dark:text-text-secondary text-gray-500">Input Tokens</span>
+            <span className="dark:text-text-primary text-gray-900 font-medium tabular-nums">{inputTokens.toLocaleString()}</span>
+          </div>
+          <div className="flex justify-between text-xs">
+            <span className="dark:text-text-secondary text-gray-500">Output Tokens</span>
+            <span className="dark:text-text-primary text-gray-900 font-medium tabular-nums">{outputTokens.toLocaleString()}</span>
+          </div>
+          <div className="border-t dark:border-border border-gray-200 pt-2 flex justify-between text-xs">
+            <span className="font-semibold dark:text-text-primary text-gray-900">Total Tokens</span>
+            <span className="font-bold dark:text-text-primary text-gray-900 tabular-nums">{totalTokens.toLocaleString()}</span>
+          </div>
+        </div>
+
+        {/* Cost Estimation */}
+        <div className="col-span-1 border-t md:border-t-0 md:border-l dark:border-border border-gray-200 pt-3 md:pt-0 md:pl-4 flex flex-col justify-center">
+          <span className="text-[10px] dark:text-text-secondary text-gray-500 uppercase tracking-wider font-semibold mb-1">
+            Estimated Cost
+          </span>
+          <div className="text-2xl font-bold dark:text-text-primary text-gray-900 tabular-nums tracking-tight">
+             {pricing ? formatCost(totalCost) : '—'}
+          </div>
+          {!pricing && (
+            <span className="text-[10px] text-gray-400 mt-1">Pricing unavailable</span>
+          )}
+        </div>
+      </div>
+      
+      <div className="mt-3 flex items-start gap-1.5 text-[10px] dark:text-text-muted text-gray-400">
+        <Info size={12} className="shrink-0 mt-[1px]" />
+        <p>
+          These values are approximate estimates based on a standard calculation (1 token ≈ 4 chars). Actual billing by the provider may vary.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Closes #814

Implemented an **AI Token Usage & Cost Estimator** that displays token usage and estimated execution costs after an agent successfully completes a run.

* Added a new `ExecutionCostPanel` component to display input/output tokens, provider, model, and total estimated cost.
* Integrated the panel into `AgentRunner.jsx` so it appears beneath the generated markdown output after successful execution.
* Added input/output token calculation and state handling to the agent runner.
* Reused the existing `estimateInputCost` and `estimateOutputCost` functions from `modelPricing.js` for accurate pricing.
* Added graceful handling for very small costs by displaying `< $0.0001` instead of scientific notation.

## Type of change

* [ ] New agent
* [ ] Bug fix
* [ ] UI improvement
* [x] Other

## Checklist

* [ ] I ran `npm run build` locally and it passed ✅
* [x] I tested my changes in the browser ✅
* [x] I did not break any existing agents ✅
* [x] I did not use `import agents from '../agents/registry'` ✅
* [x] My PR has a clear description above ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token usage estimates for completed agent executions.
  * Added an execution cost panel showing input, output, and total estimated costs.
  * Displays the selected model and provider, with pricing information and applicable disclaimers.

* **Bug Fixes**
  * Token estimates now reset when changing agents, starting new runs, or resetting forms.
  * Cost details remain hidden when token usage is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->