### PR TITLE
feat: add agent run usage tracking (tokens, cost, success rate)

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -14,7 +14,9 @@ function createNoopQuery(result = { data: [], error: null }) {
     insert: () => query,
     update: () => query,
     eq: () => query,
+    gte: () => query,
     order: () => query,
+    range: () => query,
     single: () => createNoopQuery({ data: null, error: null }),
     then: (resolve) => Promise.resolve(result).then(resolve),
   }

--- a/src/lib/useAgentRunMetrics.js
+++ b/src/lib/useAgentRunMetrics.js
@@ -1,55 +1,88 @@
-import { useState, useEffect, useCallback } from 'react'
-import { supabase } from './supabase'
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "./supabase";
 
 const PRICING = {
-  'gpt-4o': { input: 0.005, output: 0.015 },
-  'claude-sonnet': { input: 0.003, output: 0.015 },
-}
+  "gpt-4o": { input: 0.005, output: 0.015 },
+  "claude-sonnet": { input: 0.003, output: 0.015 },
+};
 
 export function estimateCost(model, inputTokens, outputTokens) {
-  const p = PRICING[model] || { input: 0, output: 0 }
-  return (inputTokens / 1000) * p.input + (outputTokens / 1000) * p.output
+  const p = PRICING[model];
+  if (!p) return null; // unknown model — don't silently record as $0
+  return (inputTokens / 1000) * p.input + (outputTokens / 1000) * p.output;
 }
 
-export async function logAgentRun({ agentRunId, model, inputTokens, outputTokens, status, durationMs }) {
-  const estimatedCostUSD = estimateCost(model, inputTokens, outputTokens)
-  return supabase.from('agent_runs').insert({
+export async function logAgentRun({
+  agentRunId,
+  model,
+  inputTokens,
+  outputTokens,
+  status,
+  durationMs,
+}) {
+  const cost = estimateCost(model, inputTokens, outputTokens);
+  return supabase.from("agent_runs").insert({
     agent_run_id: agentRunId,
     model,
     input_tokens: inputTokens,
     output_tokens: outputTokens,
-    estimated_cost_usd: estimatedCostUSD,
+    estimated_cost_usd: cost, // null when pricing is unknown, not 0
     status,
     duration_ms: durationMs,
     timestamp: new Date().toISOString(),
-  })
+  });
 }
 
 export function useAgentRunMetrics(rangeDays = 30) {
-  const [runs, setRuns] = useState([])
-  const [loading, setLoading] = useState(true)
+  const [runs, setRuns] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   const fetchRuns = useCallback(async () => {
-    setLoading(true)
-    const since = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000).toISOString()
-    const { data, error } = await supabase
-      .from('agent_runs')
-      .select('*')
-      .order('timestamp', { ascending: false })
-    if (!error && data) {
-      setRuns(data.filter((r) => r.timestamp >= since))
+    setLoading(true);
+    try {
+      const since = new Date(
+        Date.now() - rangeDays * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const { data, error } = await supabase
+        .from("agent_runs")
+        .select("*")
+        .gte("timestamp", since)
+        .order("timestamp", { ascending: false });
+      if (!error && data) {
+        setRuns(data);
+      }
+    } finally {
+      setLoading(false);
     }
-    setLoading(false)
-  }, [rangeDays])
+  }, [rangeDays]);
 
-  useEffect(() => { fetchRuns() }, [fetchRuns])
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
 
-  const totalRuns = runs.length
-  const successCount = runs.filter((r) => r.status === 'success').length
-  const successRate = totalRuns ? (successCount / totalRuns) * 100 : 0
-  const totalTokens = runs.reduce((sum, r) => sum + (r.input_tokens || 0) + (r.output_tokens || 0), 0)
-  const totalCostUSD = runs.reduce((sum, r) => sum + (r.estimated_cost_usd || 0), 0)
-  const avgDurationMs = totalRuns ? runs.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / totalRuns : 0
+  const totalRuns = runs.length;
+  const successCount = runs.filter((r) => r.status === "success").length;
+  const successRate = totalRuns ? (successCount / totalRuns) * 100 : 0;
+  const totalTokens = runs.reduce(
+    (sum, r) => sum + (r.input_tokens || 0) + (r.output_tokens || 0),
+    0,
+  );
+  const totalCostUSD = runs.reduce(
+    (sum, r) => sum + (r.estimated_cost_usd || 0),
+    0,
+  );
+  const avgDurationMs = totalRuns
+    ? runs.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / totalRuns
+    : 0;
 
-  return { runs, loading, totalRuns, successRate, totalTokens, totalCostUSD, avgDurationMs, refetch: fetchRuns }
+  return {
+    runs,
+    loading,
+    totalRuns,
+    successRate,
+    totalTokens,
+    totalCostUSD,
+    avgDurationMs,
+    refetch: fetchRuns,
+  };
 }

--- a/src/lib/useAgentRunMetrics.js
+++ b/src/lib/useAgentRunMetrics.js
@@ -67,13 +67,15 @@ export function useAgentRunMetrics(rangeDays = 30) {
     (sum, r) => sum + (r.input_tokens || 0) + (r.output_tokens || 0),
     0,
   );
-  const totalCostUSD = runs.reduce(
-    (sum, r) => sum + (r.estimated_cost_usd || 0),
-    0,
-  );
+ const totalCostUSD = runs.reduce(
+    (sum, r) => (r.estimated_cost_usd == null ? sum : sum + r.estimated_cost_usd),
+    0
+  )
+  const unknownCostRuns = runs.filter((r) => r.estimated_cost_usd == null).length
   const avgDurationMs = totalRuns
     ? runs.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / totalRuns
     : 0;
+    return { runs, loading, totalRuns, successRate, totalTokens, totalCostUSD, unknownCostRuns, avgDurationMs, refetch: fetchRuns }
 
   return {
     runs,

--- a/src/lib/useAgentRunMetrics.js
+++ b/src/lib/useAgentRunMetrics.js
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from './supabase'
+
+const PRICING = {
+  'gpt-4o': { input: 0.005, output: 0.015 },
+  'claude-sonnet': { input: 0.003, output: 0.015 },
+}
+
+export function estimateCost(model, inputTokens, outputTokens) {
+  const p = PRICING[model] || { input: 0, output: 0 }
+  return (inputTokens / 1000) * p.input + (outputTokens / 1000) * p.output
+}
+
+export async function logAgentRun({ agentRunId, model, inputTokens, outputTokens, status, durationMs }) {
+  const estimatedCostUSD = estimateCost(model, inputTokens, outputTokens)
+  return supabase.from('agent_runs').insert({
+    agent_run_id: agentRunId,
+    model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    estimated_cost_usd: estimatedCostUSD,
+    status,
+    duration_ms: durationMs,
+    timestamp: new Date().toISOString(),
+  })
+}
+
+export function useAgentRunMetrics(rangeDays = 30) {
+  const [runs, setRuns] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchRuns = useCallback(async () => {
+    setLoading(true)
+    const since = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000).toISOString()
+    const { data, error } = await supabase
+      .from('agent_runs')
+      .select('*')
+      .order('timestamp', { ascending: false })
+    if (!error && data) {
+      setRuns(data.filter((r) => r.timestamp >= since))
+    }
+    setLoading(false)
+  }, [rangeDays])
+
+  useEffect(() => { fetchRuns() }, [fetchRuns])
+
+  const totalRuns = runs.length
+  const successCount = runs.filter((r) => r.status === 'success').length
+  const successRate = totalRuns ? (successCount / totalRuns) * 100 : 0
+  const totalTokens = runs.reduce((sum, r) => sum + (r.input_tokens || 0) + (r.output_tokens || 0), 0)
+  const totalCostUSD = runs.reduce((sum, r) => sum + (r.estimated_cost_usd || 0), 0)
+  const avgDurationMs = totalRuns ? runs.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / totalRuns : 0
+
+  return { runs, loading, totalRuns, successRate, totalTokens, totalCostUSD, avgDurationMs, refetch: fetchRuns }
+}

--- a/src/lib/useAgentRunMetrics.js
+++ b/src/lib/useAgentRunMetrics.js
@@ -75,15 +75,14 @@ export function useAgentRunMetrics(rangeDays = 30) {
   const avgDurationMs = totalRuns
     ? runs.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / totalRuns
     : 0;
-    return { runs, loading, totalRuns, successRate, totalTokens, totalCostUSD, unknownCostRuns, avgDurationMs, refetch: fetchRuns }
-
-  return {
+    return {
     runs,
     loading,
     totalRuns,
     successRate,
     totalTokens,
     totalCostUSD,
+    unknownCostRuns,
     avgDurationMs,
     refetch: fetchRuns,
   };


### PR DESCRIPTION
## What does this PR do?
Adds usage-tracking foundation for the agent performance metrics dashboard requested in #923. Introduces a `useAgentRunMetrics` hook and a `logAgentRun` helper that write to a new `agent_runs` Supabase table, capturing tokens, estimated cost (via a per-model pricing formula), success/failure/timeout status, and run duration.

This is step 1 of the feature (usage tracking). The metrics dashboard UI (to be added to `AnalyticsPage.jsx`) will be a follow-up PR.

**Note:** The `agent_runs` table migration SQL is below needs to be run in Supabase SQL Editor once (project was paused when I pushed this):
```sql
create table if not exists agent_runs (
  id uuid primary key default gen_random_uuid(),
  agent_run_id text not null,
  model text not null,
  input_tokens integer default 0,
  output_tokens integer default 0,
  estimated_cost_usd numeric default 0,
  status text check (status in ('success', 'failed', 'timeout')),
  duration_ms integer,
  timestamp timestamptz default now()
);
```

## Type of change
- [ ] New agent
- [x] Other (new data/analytics utility — no agent or UI change yet)

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅ *(pending — run before merge)*
- [ ] I tested my changes in the browser ✅ *(pending table creation)*
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — no UI in this PR

closes #923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent run monitoring with configurable date ranges.
  * Displays run counts, success rates, token usage, estimated costs, and average duration.
  * Supports recording agent run details and refreshing metrics.
  * Provides pricing-based cost estimates for supported models and tracks runs with unknown costs separately.

* **Bug Fixes**
  * Preserves existing results when metric retrieval encounters an error.
  * Ensures metric loading completes even when retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->