### PR TITLE
feat: seed Coding Assistant, Data Analysis, and Web Scraping agent templates

### DIFF
--- a/src/agents/definitions/coding-assistant-agent.js
+++ b/src/agents/definitions/coding-assistant-agent.js
@@ -1,0 +1,52 @@
+export default {
+  id: "coding-assistant-agent",
+  createdAt: "2026-08-14",
+  name: "Coding Assistant",
+  description:
+    "Paste a coding problem or existing code and get an implementation, explanation, or fix.",
+  category: "Developer Tools",
+  icon: "Code",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    task: "Write a function that debounces another function by a given delay.",
+    language: "JavaScript",
+  },
+  inputs: [
+    {
+      id: "task",
+      label: "What do you need?",
+      type: "textarea",
+      placeholder: "Describe the task, paste code to fix, or ask a question",
+      required: true,
+    },
+    {
+      id: "language",
+      label: "Language",
+      type: "select",
+      options: [
+        "JavaScript",
+        "TypeScript",
+        "Python",
+        "Go",
+        "Rust",
+        "Java",
+        "C#",
+        "Other",
+      ],
+      defaultValue: "JavaScript",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a senior software engineer. Given a coding task or existing code, respond with a working solution.
+
+Rules:
+- Prefer clear, idiomatic code over clever code
+- Include a brief explanation before the code block
+- If fixing existing code, explain what was wrong
+- Call out any assumptions you had to make
+- Note edge cases the solution does or doesn't handle`,
+  outputType: "markdown",
+  suggestedChainFrom: ["api-doc-generator"],
+};

--- a/src/agents/definitions/data-analysis-agent.js
+++ b/src/agents/definitions/data-analysis-agent.js
@@ -1,0 +1,53 @@
+export default {
+  id: "data-analysis-agent",
+  createdAt: "2026-08-14",
+  name: "Data Analysis Agent",
+  description:
+    "Paste tabular data or a dataset description and get a structured analysis with key patterns and caveats.",
+  category: "Data Science",
+  icon: "BarChart3",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    data: "date,revenue,region\n2026-01,4200,East\n2026-02,3900,East\n2026-01,5100,West",
+    question: "What trends stand out by region over time?",
+  },
+  inputs: [
+    {
+      id: "data",
+      label: "Data (CSV, JSON, or description)",
+      type: "textarea",
+      placeholder: "Paste your data here",
+      required: true,
+    },
+    {
+      id: "question",
+      label: "What do you want to know?",
+      type: "text",
+      placeholder: "e.g. What trends stand out?",
+      required: false,
+    },
+  ],
+  systemPrompt: `You are a data analyst. Given tabular data (or a description of a dataset), produce a structured analysis.
+
+Format:
+## Summary
+What the data shows at a glance.
+
+## Key Patterns
+Bulleted observations — trends, outliers, correlations.
+
+## Caveats
+Sample size limits, missing data, or anything that limits confidence in the findings.
+
+## Answer to Question
+If the user asked a specific question, answer it directly using the data.
+
+Rules:
+- Never invent data points not present in the input
+- If the data is too sparse to support a claim, say so
+- Be precise with numbers you do cite`,
+  outputType: "markdown",
+  suggestedChainFrom: [],
+};

--- a/src/agents/definitions/web-scraping-agent.js
+++ b/src/agents/definitions/web-scraping-agent.js
@@ -1,0 +1,43 @@
+export default {
+  id: "web-scraping-agent",
+  createdAt: "2026-08-14",
+  name: "Web Scraping Agent",
+  description:
+    "Describe a page's content or paste raw HTML and get clean, structured data extracted from it.",
+  category: "Developer Tools",
+  icon: "Globe",
+  provider: "any",
+  defaultProvider: "anthropic",
+  model: "claude-sonnet-4-6",
+  exampleInputs: {
+    content: "<div class='product'><h2>Wireless Mouse</h2><span class='price'>$24.99</span></div>",
+    fields: "name, price",
+  },
+  inputs: [
+    {
+      id: "content",
+      label: "HTML or page text",
+      type: "textarea",
+      placeholder: "Paste raw HTML or copied page content",
+      required: true,
+    },
+    {
+      id: "fields",
+      label: "Fields to extract",
+      type: "text",
+      placeholder: "e.g. name, price, date",
+      required: true,
+    },
+  ],
+  systemPrompt: `You are a data extraction specialist. Given raw HTML or pasted page text and a list of desired fields, extract structured data.
+
+Output valid JSON: an array of objects, one per record found, using the requested field names as keys.
+
+Rules:
+- Extract only what's actually present in the input — never fabricate values
+- If a requested field isn't found for a record, set it to null
+- If multiple records are present, return all of them
+- Strip HTML tags and clean up whitespace in extracted text`,
+  outputType: "json",
+  suggestedChainFrom: [],
+};


### PR DESCRIPTION
## What does this PR do?
Adds 3 new pre-built agent templates addressing the "blank slate" onboarding problem in #921: Coding Assistant, Data Analysis Agent, and Web Scraping Agent. (A Research Agent template already existed in the codebase.)

These are picked up automatically by the existing `import.meta.glob` registry (`src/agents/registry.js`) — no registry changes needed. They also slot directly into the existing Marketplace infrastructure (`src/lib/marketplace.js` — `filterListings`, `importAgent`, `publishAgent`) and `MarketplacePage.jsx`, which already implement a filterable category gallery, one-click "use this template" cloning, and community publishing.

Given that infra already exists, this PR only adds the missing agent definitions rather than a new schema/UI — steps 2-4 of the issue's proposed solution (gallery UI, one-click use, community submissions) appear to already be covered by the existing Marketplace.

## Type of change
- [x] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] I ran `npm run build` locally and it passed ✅ *(pending)*
- [ ] I tested my changes in the browser ✅ *(pending)*
- [x] I did not break any existing agents ✅
- [x] I did not use `import agents from '../agents/registry'` ✅
- [x] My PR has a clear description above ✅

## Screenshots (if UI change)
N/A — no UI code changed; new agents surface automatically through the existing Marketplace/registry.

closes #921