### PR TITLE
feat:back button on privacy and terms pages- #1739

### DIFF
--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -7,6 +7,7 @@ import {
   Mail,
   Calendar,
   RefreshCw,
+  ArrowLeft,
 } from "lucide-react";
 
 const sections = [
@@ -61,6 +62,11 @@ const sections = [
 ];
 
 export default function Privacy() {
+   const handleBack = () => {
+    if (typeof window !== "undefined") {
+      window.history.back();
+    }
+  };
   return (
     <div className="min-h-screen bg-[#06070A] text-white overflow-hidden">
       {/* Background */}
@@ -70,7 +76,16 @@ export default function Privacy() {
         <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.03)_1px,transparent_1px)] bg-[size:60px_60px]" />
       </div>
 
-      <div className="max-w-6xl mx-auto px-6 py-20">
+      <div className="max-w-6xl mx-auto px-6 py-20 relative">
+      <div className="absolute top-6 left-6 md:top-10 md:left-6">
+          <button
+            onClick={handleBack}
+            className="flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-slate-300 backdrop-blur-md transition duration-300 hover:text-cyan-400 hover:border-cyan-400/30 hover:bg-gradient-to-r hover:from-cyan-500/10 hover:to-fuchsia-500/10"
+          >
+            <ArrowLeft size={16} />
+            <span className="text-sm font-medium">Back</span>
+          </button>
+        </div>
         <div className="text-center">
           <div className="inline-flex items-center gap-2 px-5 py-2 rounded-full bg-gradient-to-r from-cyan-500/20 to-fuchsia-500/20 border border-cyan-400/20 mb-6">
             <ShieldCheck className="h-5 w-5 text-cyan-400" />

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   Mail,
   Calendar,
+  ArrowLeft,
 } from "lucide-react";
 
 const sections = [
@@ -55,6 +56,11 @@ const sections = [
 ];
 
 export default function TermsOfService() {
+  const handleBack = () => {
+    if (typeof window !== "undefined") {
+      window.history.back();
+    }
+  };
   return (
     <div className="min-h-screen bg-[#06070A] text-white overflow-hidden">
       {/* Background */}
@@ -64,7 +70,16 @@ export default function TermsOfService() {
         <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.03)_1px,transparent_1px)] bg-[size:60px_60px]" />
       </div>
 
-      <div className="max-w-6xl mx-auto px-6 py-20">
+      <div className="max-w-6xl mx-auto px-6 py-20 relative">
+        <div className="absolute top-6 left-6 md:top-10 md:left-6">
+          <button
+            onClick={handleBack}
+            className="flex items-center gap-2 px-4 py-2 rounded-full border border-white/10 bg-white/5 text-slate-300 backdrop-blur-md transition duration-300 hover:text-cyan-400 hover:border-cyan-400/30 hover:bg-gradient-to-r hover:from-cyan-500/10 hover:to-fuchsia-500/10"
+          >
+            <ArrowLeft size={16} />
+            <span className="text-sm font-medium">Back</span>
+          </button>
+        </div>
         <div className="text-center">
           <div className="inline-flex items-center gap-2 px-5 py-2 rounded-full bg-gradient-to-r from-cyan-500/20 to-fuchsia-500/20 border border-cyan-400/20 mb-6">
             <FileText className="h-5 w-5 text-cyan-400" />


### PR DESCRIPTION
## What does this PR do?
<!-- Describe your changes clearly -->
feat: This PR added Back button on privacy and terms pages with proper css.
Closes #937 
Changes
-Added a visible “Back” button on the privacy and terms pages
-Proper css visuals on the button
Results
-since changes are done in frontend, no error or changes in backend.
## Type of change
- [ ] New agent
- [ ] Bug fix
- [ ] UI improvement
- [ ] Documentation
- [ X] Other {enhancement}

## Checklist
- [X ] I ran `npm run build` locally and it passed ✅
- [ X] I tested my changes in the browser ✅
- [ X] I did not break any existing agents ✅
- [ X] I did not use `import agents from '../agents/registry'` ✅
- [ X] My PR has a clear description above ✅

## Screenshots (if UI change)
<!-- Add screenshots here -->
<img width="1361" height="578" alt="Screenshot 2026-08-15 004126" src="https://github.com/user-attachments/assets/36ffd958-7a9d-45e4-be11-ce6f62cff96e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Back” button to the Privacy Policy and Terms of Service pages.
  * The button returns visitors to the previous page and includes a directional arrow for clarity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->