### PR TITLE
fix: show API key required state for scheduled jobs

### DIFF
--- a/src/lib/useScheduler.js
+++ b/src/lib/useScheduler.js
@@ -141,6 +141,14 @@ export function useScheduler({ autoRun = true } = {}) {
     removeStoredJobKey(jobId)
     setJobs(prev => prev.filter(j => j.id !== jobId))
   }, [])
+  // Re-supply an API key for a job whose key was lost (e.g. tab closed
+  // and sessionStorage was cleared).
+  const updateJobKey = useCallback((jobId, apiKey) => {
+    setStoredJobKey(jobId, apiKey)
+    setJobs(prev => prev.map(j =>
+      j.id === jobId ? { ...j, apiKey } : j
+    ))
+  }, [])
 
   // ── Delete a result
   const deleteResult = useCallback((resultId) => {
@@ -277,6 +285,7 @@ export function useScheduler({ autoRun = true } = {}) {
     addJob,
     toggleJob,
     deleteJob,
+    updateJobKey,
     deleteResult,
     clearResultsForJob,
     runJob,

--- a/src/pages/SchedulerPage.jsx
+++ b/src/pages/SchedulerPage.jsx
@@ -41,11 +41,21 @@ export default function SchedulerPage() {
     jobs, results, running,
     toggleJob, deleteJob, runJob,
     deleteResult, clearResultsForJob,
+    updateJobKey,
   } = useScheduler()
 
   const [expandedJob, setExpandedJob] = useState(null)
   const [expandedResult, setExpandedResult] = useState(null)
   const [confirmDelete, setConfirmDelete] = useState(null)
+  const [keyInputJobId, setKeyInputJobId] = useState(null)
+  const [keyInputValue, setKeyInputValue] = useState('')
+
+  const handleSaveKey = (jobId) => {
+    if (!keyInputValue.trim()) return
+    updateJobKey(jobId, keyInputValue.trim())
+    setKeyInputJobId(null)
+    setKeyInputValue('')
+  }
 
   const handleRequestNotification = () => {
     if (!('Notification' in window)) return
@@ -89,6 +99,16 @@ export default function SchedulerPage() {
         )}
       </div>
 
+      {/* Background execution notice */}
+      <div className="flex items-start gap-2 mb-6 px-3 py-2.5 rounded-lg text-xs
+        dark:bg-surface-hover dark:text-text-secondary bg-gray-50 text-gray-500 border dark:border-border border-gray-200">
+        <AlertCircle size={14} className="flex-shrink-0 mt-0.5" />
+        <span>
+          Scheduled jobs currently run only while this app is open in a browser tab, and their API key
+          is cleared when that tab closes. If a job stops running, check for an "API key required" notice below.
+        </span>
+      </div>
+
       {/* Empty state */}
       {jobs.length === 0 && (
         <div className="text-center py-16 rounded-xl border dark:bg-surface-card dark:border-border bg-white border-gray-200">
@@ -112,6 +132,8 @@ export default function SchedulerPage() {
             const isRunning = running[job.id]
             const scheduleLabel = SCHEDULE_OPTIONS.find(s => s.value === job.schedule)?.label ?? job.schedule
             const isExpanded = expandedJob === job.id
+            const needsKey = job.enabled && !job.apiKey
+            const isEnteringKey = keyInputJobId === job.id
 
             return (
               <div
@@ -144,6 +166,13 @@ export default function SchedulerPage() {
                           Paused
                         </span>
                       )}
+                      {needsKey && (
+                        <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full
+                          bg-amber-500/10 text-amber-500 border border-amber-500/20">
+                          <AlertCircle size={10} />
+                          API key required
+                        </span>
+                      )}
                     </div>
                     <div className="flex items-center gap-3 mt-0.5 flex-wrap">
                       <span className="text-[11px] dark:text-text-muted text-gray-400">
@@ -152,12 +181,48 @@ export default function SchedulerPage() {
                       <span className="text-[11px] dark:text-text-muted text-gray-400">
                         Last run: {formatDate(job.lastRunAt)}
                       </span>
-                      {job.enabled && (
+                      {job.enabled && !needsKey && (
                         <span className="text-[11px] text-accent">
                           Next: {formatNextRun(job.nextRunAt)}
                         </span>
                       )}
+                      {needsKey && !isEnteringKey && (
+                        <button
+                          onClick={() => { setKeyInputJobId(job.id); setKeyInputValue('') }}
+                          className="text-[11px] text-amber-500 hover:underline font-medium"
+                        >
+                          This job can't run - add an API key
+                        </button>
+                      )}
                     </div>
+
+                    {isEnteringKey && (
+                      <div className="flex items-center gap-1.5 mt-2">
+                        <input
+                          type="password"
+                          autoFocus
+                          value={keyInputValue}
+                          onChange={(e) => setKeyInputValue(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') handleSaveKey(job.id) }}
+                          placeholder={`API key for ${job.provider || 'this provider'}`}
+                          className="flex-1 text-xs px-2 py-1 rounded-md border
+                            dark:bg-surface-input dark:border-border dark:text-text-primary
+                            bg-white border-gray-200 text-gray-900"
+                        />
+                        <button
+                          onClick={() => handleSaveKey(job.id)}
+                          className="text-[11px] font-medium text-white bg-accent hover:opacity-90 px-2.5 py-1 rounded-md transition-opacity"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={() => setKeyInputJobId(null)}
+                          className="p-1 rounded-md dark:text-text-muted text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          <X size={13} />
+                        </button>
+                      </div>
+                    )}
                   </div>
 
                   {/* Actions */}


### PR DESCRIPTION
## Closes #926

## Summary

Implements the short-term fix from the issue so scheduled jobs no longer fail silently when they don't have an API key.

## Changes

### `src/lib/useScheduler.js`

* Added `updateJobKey(jobId, apiKey)` to re-add a job's API key to both `sessionStorage` and the in-memory state.
* This allows users to restore a missing key without deleting and recreating the job.

### `src/pages/SchedulerPage.jsx`

* Added a notice below the header explaining that scheduled jobs currently run only while the app is open in a browser tab, and that the API key is cleared when the tab is closed.
* Added a `needsKey` check (`job.enabled && !job.apiKey`) for each job.
* When a job needs a key:

  * Shows an amber **"API key required"** badge next to the schedule.
  * Replaces the **"Next: ..."** text with a **"This job can't run — add an API key"** link.
  * Clicking the link shows an inline password field so the API key can be entered and saved without recreating the job.

## Why this scope

This covers the three short-term fixes discussed in the issue:

1. Make the broken state visible.
2. Provide a way to re-enter the API key.
3. Clearly explain the current tab-open requirement.

The longer-term background execution problem (service workers / Push API) is left out of this PR since it would need a separate design discussion.

## Testing

* `npm run build` completes successfully with no errors.
* Manually verified that the notice appears correctly on `/scheduler`.
* Tested the `needsKey` badge, link, and inline input by adding a test job directly to `localStorage` without a matching `sessionStorage` key. This simulates the state that occurs when the API key is no longer available, without having to wait for the browser tab to close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to enter, save, replace, or cancel an API key directly from the scheduler job list.
  * Jobs requiring an API key now clearly display an “API key required” status.
  * Added keyboard support for saving API keys with Enter.

* **Improvements**
  * Jobs without an API key no longer display a misleading next-run indicator.
  * Added a notice explaining that scheduled jobs run only while the app is open and keys are cleared when the tab closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->